### PR TITLE
some initial super simple specs

### DIFF
--- a/spec/searchers/quick_search/article_searcher_spec.rb
+++ b/spec/searchers/quick_search/article_searcher_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe QuickSearch::ArticleSearcher do
+  subject(:searcher) { described_class.new(instance_double(HTTPClient), query, 10) }
+  let(:query) { 'my query' }
+  let(:response) { JSON.dump(response: { docs: [] }) }
+
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: response))
+  end
+  it { expect(searcher).to be_an(QuickSearch::Searcher) }
+  it { expect(searcher.search).to be_an(ArticleSearchService::Response) }
+  it do
+    searcher.search # loads response
+    expect(searcher.results).to be_an(Array)
+  end
+end

--- a/spec/searchers/quick_search/catalog_searcher_spec.rb
+++ b/spec/searchers/quick_search/catalog_searcher_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe QuickSearch::CatalogSearcher do
+  subject(:searcher) { described_class.new(instance_double(HTTPClient), query, 10) }
+  let(:query) { 'my query' }
+  let(:response) { JSON.dump(response: { docs: [] }) }
+
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: response))
+  end
+  it { expect(searcher).to be_an(QuickSearch::Searcher) }
+  it { expect(searcher.search).to be_an(CatalogSearchService::Response) }
+  it do
+    searcher.search # loads response
+    expect(searcher.results).to be_an(Array)
+  end
+end

--- a/spec/services/article_search_service_spec.rb
+++ b/spec/services/article_search_service_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ArticleSearchService do
+  subject(:service) { described_class.new }
+  let(:response) { JSON.dump(response: { docs: [] }) }
+  let(:query) { ArticleSearchService::Request.new('my query') }
+  
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: response))
+  end
+
+  it { expect(service).to be_an AbstractSearchService }
+  it { expect(service.search(query)).to be_an ArticleSearchService::Response }
+end

--- a/spec/services/catalog_search_service_spec.rb
+++ b/spec/services/catalog_search_service_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe CatalogSearchService do
+  subject(:service) { described_class.new }
+  let(:response) { JSON.dump(response: { docs: [] }) }
+  let(:query) { CatalogSearchService::Request.new('my query') }
+
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: response))
+  end
+
+  it { expect(service).to be_an AbstractSearchService }
+  it { expect(service.search(query)).to be_an CatalogSearchService::Response }
+end


### PR DESCRIPTION
```
QuickSearch::CatalogSearcher
  should be a kind of CatalogSearchService::Response
  should be a kind of QuickSearch::Searcher
  should be a kind of Array

CatalogSearchService
  should be a kind of CatalogSearchService::Response
  should be a kind of AbstractSearchService

ArticleSearchService
  should be a kind of AbstractSearchService
  should be a kind of ArticleSearchService::Response

QuickSearch::ArticleSearcher
  should be a kind of QuickSearch::Searcher
  should be a kind of Array
  should be a kind of ArticleSearchService::Response

Finished in 0.03323 seconds (files took 3.27 seconds to load)
10 examples, 0 failures
```