### PR TITLE
modify responsiveness of searchbar

### DIFF
--- a/app/assets/stylesheets/quick_search_overrides.scss
+++ b/app/assets/stylesheets/quick_search_overrides.scss
@@ -9,29 +9,16 @@
 }
 
 .search-container {
-  display: inline-block;
-  width: 100%;
-  margin: 0 auto;
-  text-align: center;
-
-  h1 {
-    display: inline-block;
+  label {
     color: #9D2520;
+    font-size: 40px;
+    padding-right: 20px;
   }
 
-  .main-search-form {
-    margin-left: 20px;
-    display: inline-block;
-    vertical-align: text-bottom;
-
-    .form-control {
-      display: inline-block;
+  .main-search-form {    
+    .search-input-container {
+      padding-top: 18px;
     }
-
-    .search-query {
-      width: 38rem;
-    }
-
     .search-btn {
       background-color: #9D2520;
       color: white;

--- a/app/views/layouts/quick_search/_search_form.html.erb
+++ b/app/views/layouts/quick_search/_search_form.html.erb
@@ -1,18 +1,22 @@
 <div class="search-container">
-  <h1>Search</h1>
-  <div class="main-search-form">
-    <%= form_for("search", method: :get, html: {id: 'main-search-form', class: 'form-inline'}) do |f| %>
-    <% if @query  %>
-    <input type="search" name="q" id="params-q" class="search-query form-control" value="<%= @query %>"/>
-  <% else %>
-    <input type="search" name="q" id="params-q" class="search-query form-control" placeholder="<%= @search_form_placeholder %>"/>
-    <% end %>
-    <span class="input-group-btn">
-      <button type="submit" class="btn search-btn">
-        <span class="sr-only">Search</span>
-        <i class="fa fa-search" aria-hidden="true"></i>
-      </button>
-    </span>
-    <% end %>
+  <div class="main-search-form row justify-content-center">
+    <div class="form-group col-8 text-center">
+      <%= form_for("search", method: :get, html: {id: 'main-search-form'}) do |f| %>
+        <div class='form-group row'>
+          <label for="params-q" class='col-md-4 col-form-label'>Search</label>
+          <div class='col-md-8 search-input-container'>
+            <div class='input-group'>
+              <input type="search" name="q" id="params-q" class="search-query form-control" value="<%= @query %>" placeholder="<%= @search_form_placeholder %>"/>
+              <span class="input-group-btn">
+                <button type="submit" class="btn search-btn">
+                  <span class="sr-only">Search</span>
+                  <i class="fa fa-search" aria-hidden="true"></i>
+                </button>
+              </span>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/layouts/quick_search/application.html.erb
+++ b/app/views/layouts/quick_search/application.html.erb
@@ -24,13 +24,13 @@
   <body class="<%= body_class %>" data-quicksearch-ga-query="<%= strip_tags(@log_query) %>">
     <%= render '/layouts/quick_search/header' %>
     <div id="content" role="document" class="page">
-      <div class="container">
-        <main id="main-content" role="main" class="row l-main">
+      <div class="">
+        <main id="main-content" role="main" class="">
           <div class="skip-link">
             <a href="#main-content"></a>
           </div>
           <!-- CONTENT: enter content below this line -->
-          <div id="quicksearch">
+          <div id="quicksearch" class='container'>
             <%= yield %>
           </div>
         </main>


### PR DESCRIPTION
This also solves a bug where the columns when first loading a search result would push together.

Part of the work on #12 

This moves the search bar styling and responsiveness to be more "Bootstrappy". @camillevilla I would love your thoughts on this b/c of your work on some of the styling stuff already.

![searchbar](https://user-images.githubusercontent.com/1656824/30391535-c1e5c8b8-9887-11e7-874e-c07eaa572a3e.gif)
