### PR TITLE
Display total counts of searchers in the searcher anchors

### DIFF
--- a/app/views/layouts/quick_search/_found_types.html.erb
+++ b/app/views/layouts/quick_search/_found_types.html.erb
@@ -1,0 +1,23 @@
+<% # overriden from the QuickSearch gem %>
+<div class='row searcher-anchors'>
+  <dt class='col-sm-3 text-right'>Found results in</dt>
+  <dd class='col-sm-19'>
+    <ul class="list-inline">
+      <% QuickSearch::Engine::APP_CONFIG['found_types'].each do |searcher| %>
+        <% if @found_types.include? searcher  %>
+          <li class='list-inline-item'>
+            <a href="#<%= searcher.dasherize %>" data-quicksearch-ga-action="<%= searcher.dasherize %>">
+              <%= t("#{searcher}_search.display_name") %>
+            </a>
+          </li>
+        <% else %>
+          <li class="<%= searcher.dasherize %> list-inline-item">
+            <span class="no-results-label">
+              <%= t("#{searcher}_search.display_name") %>
+            </span>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
+  </dd>
+</dl>

--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -35,5 +35,11 @@
                 </span>
             <% end %>
         </p>
+        <% if searcher.total.present? %>
+          <script type='text/javascript'>
+            var searcherLink = $('.searcher-anchors a[href="#<%= service_name %>"]');
+            searcherLink.append('(<%= number_with_delimiter(total) %>)')
+          </script>
+        <% end %>
     <% end %>
 </div>

--- a/spec/features/searcher_anchors_spec.rb
+++ b/spec/features/searcher_anchors_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Searcher Anchor Links', js: true do
+  before do
+    allow_any_instance_of(AbstractSearchService).to receive(:search).and_return(response)
+
+    visit quick_search_path
+    fill_in 'params-q', with: 'jane stanford'
+    click_button 'Search'
+  end
+
+  context 'when a searcher has a total' do
+    let(:response) do
+      instance_double(
+        ArticleSearchService::Response,
+        results: [
+          instance_double(AbstractSearchService::Result)
+        ],
+        total: 666_666,
+        facets: [],
+        highlighted_facet_values: []
+      )
+    end
+
+    it 'updates the anchor link with the total count' do
+      expect(page).to have_css('.see-all-results', visible: true)
+
+      expect(page).to have_css('a', text: /See all 666,666 .* results/)
+
+      within '.searcher-anchors' do
+        expect(page).to have_css('a', text: 'SearchWorks articles+ (666,666)')
+      end
+    end
+  end
+
+  context 'when a searcher does not have a total' do
+    let(:response) do
+      instance_double(
+        ArticleSearchService::Response,
+        results: [
+          instance_double(AbstractSearchService::Result)
+        ],
+        total: nil,
+        facets: [],
+        highlighted_facet_values: []
+      )
+    end
+
+    it 'does not try to add the total count to the link' do
+      expect(page).to have_css('.see-all-results', visible: true)
+
+      within '.searcher-anchors' do
+        expect(page).to have_css('a', text: /^SearchWorks articles\+$/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #18

<img width="1219" alt="search-anchor-counts" src="https://user-images.githubusercontent.com/96776/30413180-758df680-98d1-11e7-95d6-2e138c5d24eb.png">
