### PR TITLE
add More search tools panel to search results and homepage

### DIFF
--- a/app/assets/images/search.svg
+++ b/app/assets/images/search.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Filled_Icons" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<g>
+	<path d="M9,18c2.131,0,4.089-0.749,5.633-1.992l7.658,7.697c0.389,0.392,1.021,0.394,1.414,0.003
+		c0.392-0.39,0.393-1.023,0.004-1.414l-7.668-7.707C17.264,13.052,18,11.111,18,9c0-4.963-4.037-9-9-9S0,4.037,0,9
+		C0,13.962,4.037,18,9,18z M9,2c3.859,0,7,3.14,7,7c0,3.859-3.141,7-7,7c-3.86,0-7-3.141-7-7C2,5.14,5.14,2,9,2z"/>
+</g>
+</svg>

--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -21,3 +21,18 @@
     padding: 2px 10px;
   }
 }
+
+.more-search-tools {
+  padding-top: 25px;
+
+  .card-body {
+    padding-left: 55px;
+  }
+
+  img {
+    width: 40px;
+    position: absolute;
+    left: 20px;
+    top: 20px;
+  }
+}

--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -36,3 +36,14 @@
     top: 20px;
   }
 }
+
+@include media-breakpoint-down(xs) {
+  .more-search-tools {
+    img {
+      width: 20px;
+      position: absolute;
+      left: 30px;
+      top: 15px;
+    }
+  }
+}

--- a/app/views/quick_search/pages/home.html.erb
+++ b/app/views/quick_search/pages/home.html.erb
@@ -5,7 +5,7 @@
       One search to see what's available in all these sources for your search topic.
   </div>
 </div>
-<div class='row homepage-panels'>
+<div class='row bento-panels homepage-panels'>
   <div class='col'>
     <div class='card'>
       <%= image_tag 'catalog.jpg', class: 'card-img-top' %>
@@ -43,3 +43,4 @@
     </div>
   </div>
 </div>
+<%= render partial: 'shared/more_search_tools' %>

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -8,7 +8,7 @@
 </div>
 <div class="quicksearch-ga-click-tracking">
   <div class="row articles-catalog">
-    <div class="col-md-6 module">
+    <div class="col-md-6 article module">
       <div id="article" class="module-contents" >
         <p class="search-error" data-quicksearch-search-endpoint="article"
                                 data-quicksearch-page=""
@@ -26,11 +26,15 @@
 </div>
 <div class="quicksearch-ga-click-tracking">
   <div class="row">
-    <div class="col-md-6 catalog module yewno">
+    <div class="col-md-6 yewno module">
       <div id="yewno" class="module-contents">
         <h2 class="result-set-heading">Yewno</h2>
         <div id="yewno-results"></div>
       </div>
     </div>
   </div>
+</div>
+
+<div class="quicksearch-ga-click-tracking">
+  <%= render partial: 'shared/more_search_tools' %>
 </div>

--- a/app/views/shared/_more_search_tools.html.erb
+++ b/app/views/shared/_more_search_tools.html.erb
@@ -1,0 +1,11 @@
+<div class='row more-search-tools homepage-panels'>
+  <div class='col-md-6'>
+    <div class='card'>
+      <%= image_tag 'search.svg', class: 'media-object card-img-left' %>
+      <div class='card-body'>
+        <h4 class='card-title'><%= link_to 'More search tools', 'https://library.stanford.edu/search-services' %></h4>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Discover and access library and archival materials, journals, databases, data, and e-resources beyond SearchWorks.</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -7,7 +7,7 @@ feature 'Homepage' do
     visit quick_search_path
   end
   scenario 'has links to various search contexts' do
-    within '.homepage-panels' do
+    within '.bento-panels' do
       expect(page).to have_css(
         'a[href="https://searchworks.stanford.edu"]',
         text: 'Catalog'
@@ -25,5 +25,11 @@ feature 'Homepage' do
         text: 'Yewno'
       )
     end
+  end
+  scenario 'has links to more search tools' do
+    expect(page).to have_css(
+      'a[href="https://library.stanford.edu/search-services"]',
+      text: 'More search tools'
+    )
   end
 end


### PR DESCRIPTION
This PR fixes #29.

### After on home page

![screen shot 2017-09-14 at 1 07 26 pm](https://user-images.githubusercontent.com/1861171/30453435-bcd70208-994d-11e7-9c45-4b3eecdbafcc.png)

### After on search results page

![screen shot 2017-09-14 at 1 07 14 pm](https://user-images.githubusercontent.com/1861171/30453451-c340203e-994d-11e7-8321-f7d8d65a97fc.png)
