### PR TITLE
Add Yewno to search anchors and fix responsive behavior

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,4 @@
 @import 'subnavbar';
 @import 'top-navbar';
 @import 'results';
+@import 'searcher-anchors';

--- a/app/assets/stylesheets/searcher-anchors.scss
+++ b/app/assets/stylesheets/searcher-anchors.scss
@@ -1,0 +1,27 @@
+.searcher-anchors {
+
+  dt {
+    text-align: right;
+  }
+
+  @include media-breakpoint-down(md) {
+    dt {
+      display: block;
+      text-align: center;
+      width: 100%;
+    }
+
+    dd {
+      display: block;
+      margin-left: 0;
+      text-align: center;
+      width: 100%;
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    li {
+      display: block;
+    }
+  }
+}

--- a/app/views/layouts/quick_search/_found_types.html.erb
+++ b/app/views/layouts/quick_search/_found_types.html.erb
@@ -18,6 +18,9 @@
           </li>
         <% end %>
       <% end %>
+      <li class='list-inline-item'>
+        <a href="#yewno" data-quicksearch-ga-action="yewno">Yewno</a>
+      </li>
     </ul>
   </dd>
 </dl>

--- a/app/views/layouts/quick_search/_found_types.html.erb
+++ b/app/views/layouts/quick_search/_found_types.html.erb
@@ -1,7 +1,7 @@
 <% # overriden from the QuickSearch gem %>
 <div class='row searcher-anchors'>
-  <dt class='col-sm-3 text-right'>Found results in</dt>
-  <dd class='col-sm-19'>
+  <dt class='col-sm-4'>Found results in</dt>
+  <dd class='col-sm-5'>
     <ul class="list-inline">
       <% QuickSearch::Engine::APP_CONFIG['found_types'].each do |searcher| %>
         <% if @found_types.include? searcher  %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,18 +2,18 @@ en:
   default_title: "Stanford Libraries"
   opensearch_description: "Stanford Libraries"
   catalog_search:
-    display_name: "SearchWorks catalog"
+    display_name: "Catalog"
+    short_display_name: "Catalog"
     sub_heading_html: Books, media, physical & digital resources
-    short_display_name: "SearchWorks catalog"
     search_form_placeholder: "Search SearchWorks catalog"
     module_callout: "Search SearchWorks catalog"
     error_service_mesasge: "searching SearchWorks catalog"
     no_results_service_message: "a different search"
     no_results_link: "http://searchworks.stanford.edu/"
   article_search:
-    display_name: "SearchWorks articles+"
+    display_name: "Articles+"
     sub_heading_html: Journal articles, e-books, & other e-resources
-    short_display_name: "SearchWorks articles+"
+    short_display_name: "Articles+"
     search_form_placeholder: "Search SearchWorks articles+"
     module_callout: "Search SearchWorks articles+"
     error_service_mesasge: "searching SearchWorks articles+"

--- a/spec/features/jumplinks_spec.rb
+++ b/spec/features/jumplinks_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Jump links', js: true do
+  before do
+    allow_any_instance_of(AbstractSearchService).to receive(:search).and_return(response)
+
+    visit quick_search_path
+    fill_in 'params-q', with: 'jane stanford'
+    click_button 'Search'
+  end
+
+  context 'searcher has results' do
+    let(:response) do
+      instance_double(
+        ArticleSearchService::Response,
+        results: [
+          instance_double(AbstractSearchService::Result)
+        ],
+        total: 666_666,
+        facets: [],
+        highlighted_facet_values: []
+      )
+    end
+
+    scenario 'points to each search module anchor' do
+      within '.result-types' do
+        expect(page).to have_css(
+          'a[href$="#catalog"]',
+          text: /Catalog/
+        )
+        expect(page).to have_css(
+          'a[href$="#article"]',
+          text: /Articles+/
+        )
+        expect(page).to have_css(
+          'a[href$="#yewno"]',
+          text: /Yewno/
+        )
+      end
+    end
+  end
+end

--- a/spec/features/searcher_anchors_spec.rb
+++ b/spec/features/searcher_anchors_spec.rb
@@ -30,7 +30,7 @@ describe 'Searcher Anchor Links', js: true do
       expect(page).to have_css('a', text: /See all 666,666 .* results/)
 
       within '.searcher-anchors' do
-        expect(page).to have_css('a', text: 'SearchWorks articles+ (666,666)')
+        expect(page).to have_css('a', text: 'Articles+ (666,666)')
       end
     end
   end
@@ -52,7 +52,7 @@ describe 'Searcher Anchor Links', js: true do
       expect(page).to have_css('.see-all-results', visible: true)
 
       within '.searcher-anchors' do
-        expect(page).to have_css('a', text: /^SearchWorks articles\+$/)
+        expect(page).to have_css('a', text: /^Articles\+$/)
       end
     end
   end


### PR DESCRIPTION
Closes #42 

This PR:
- uses shortened names for search anchors
- adds Yewno to the search anchors
- adds some responsive behavior fixes

## Before
<img width="1193" alt="search_results_before_wideview" src="https://user-images.githubusercontent.com/5402927/30498641-52c99974-9a0c-11e7-9bab-a1c85d5a8fd2.png">
<img width="397" alt="search_results_before_mobileview" src="https://user-images.githubusercontent.com/5402927/30498640-52c8f7da-9a0c-11e7-9312-134fc8523ae6.png">

## After
<img width="400" alt="search_results_after_mobileview" src="https://user-images.githubusercontent.com/5402927/30498643-52cac8ee-9a0c-11e7-84d0-966a62974ec5.png">
<img width="1141" alt="search_results_after_wideview" src="https://user-images.githubusercontent.com/5402927/30498642-52ca4cac-9a0c-11e7-9e7b-23512f333679.png">
