### PR TITLE
Add custom placeholder text

### DIFF
--- a/app/views/layouts/quick_search/_search_form.html.erb
+++ b/app/views/layouts/quick_search/_search_form.html.erb
@@ -6,7 +6,7 @@
           <label for="params-q" class='col-md-4 col-form-label'>Search</label>
           <div class='col-md-8 search-input-container'>
             <div class='input-group'>
-              <input type="search" name="q" id="params-q" class="search-query form-control" value="<%= @query %>" placeholder="<%= @search_form_placeholder %>"/>
+              <input type="search" name="q" id="params-q" class="search-query form-control" value="<%= @query %>" placeholder="<%= t('search_form.placeholder') %>"/>
               <span class="input-group-btn">
                 <button type="submit" class="btn search-btn">
                   <span class="sr-only">Search</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,3 +17,5 @@ en:
     error_service_mesasge: "searching SearchWorks articles+"
     no_results_service_message: "a different search"
     no_results_link: "http://searchworks.stanford.edu/articles"
+  search_form:
+    placeholder: "catalog + articles + website + more"


### PR DESCRIPTION
Closes #54 

This PR replaces the placeholder text provided by QuickSearch with "catalog + articles + website + more"

## Before
![placeholder_before](https://user-images.githubusercontent.com/5402927/30460729-7b2a7ef0-996d-11e7-980f-02d44bad9b75.png)

## After
![placeholder_after](https://user-images.githubusercontent.com/5402927/30460728-7b255e84-996d-11e7-9cdb-e810924452ed.png)
