### PR TITLE
change wording/styling for SearchWorks parity

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -33,6 +33,7 @@ h2 {
 }
 
 h3 {
+  font-size: 1.4em;
   font-weight: 400;
   line-height: 1.3em;
   margin: 0 0 .4em 0;

--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -9,8 +9,7 @@
     padding: 0;
   }
 
-  h4 {
-    font-size: 18px;
+  h3 {
     margin-bottom: 10px;
     margin-top: 10px;
     padding: 2px 10px;

--- a/app/views/quick_search/pages/home.html.erb
+++ b/app/views/quick_search/pages/home.html.erb
@@ -10,8 +10,8 @@
     <div class='card'>
       <%= image_tag 'catalog.jpg', class: 'card-img-top' %>
       <div class='card-body'>
-        <h4 class='card-title'><%= link_to 'Catalog', Settings.CATALOG_HOME_URL %></h4>
-        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Search the physical collections and digital resources of Stanford’s libraries. Find books, media, and topic-specific databases.</p>
+        <h3 class='card-title'><%= link_to 'Catalog', Settings.CATALOG_HOME_URL %></h3>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Search the physical collections and digital resources of Stanford’s libraries. Find books, media, and <a href="https://searchworks.stanford.edu/databases">topic-specific databases</a>.</p>
       </div>
     </div>
   </div>
@@ -19,8 +19,8 @@
     <div class='card'>
       <%= image_tag 'articles.jpg', class: 'card-img-top' %>
       <div class='card-body'>
-        <h4 class='card-title'><%= link_to 'Articles+', Settings.ARTICLES_HOME_URL %></h4>
-        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Search a combined index of 100s of databases, and connect directly to the article or resource. Covers ~87% of our subscribed databases.</p>
+        <h3 class='card-title'><%= link_to 'Articles+', Settings.ARTICLES_HOME_URL %></h3>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Search a combined index of 100s of databases, and connect directly to the article or resource.</p>
       </div>
     </div>
   </div>
@@ -28,7 +28,7 @@
     <div class='card'>
       <%= image_tag 'website.jpg', class: 'card-img-top' %>
       <div class='card-body'>
-        <h4 class='card-title'><%= link_to 'Library website', Settings.LIBRARY_WEBSITE_HOME_URL %></h4>
+        <h3 class='card-title'><%= link_to 'Library website', Settings.LIBRARY_WEBSITE_HOME_URL %></h3>
         <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Find topic specialists, blog posts, descriptions of our notable collections, as well as libraries, hours, and policies.</p>
       </div>
     </div>
@@ -37,7 +37,7 @@
     <div class='card'>
       <%= image_tag 'yewno.jpg', class: 'card-img-top' %>
       <div class='card-body'>
-        <h4 class='card-title'><%= link_to 'Yewno', Settings.YEWNO_HOME_URL %></h4>
+        <h3 class='card-title'><%= link_to 'Yewno', Settings.YEWNO_HOME_URL %></h3>
         <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Explore concepts and connections, and understand interdisciplinary subjects, in a graph interface.</p>
       </div>
     </div>


### PR DESCRIPTION
This PR fixes #60.

@jvine is the font-size for the h3 headers ok? it's not specified in [base.scss](https://github.com/sul-dlss/sul-bento-app/blob/60-cleanup/app/assets/stylesheets/base.scss#L35-L39)

### After

![screen shot 2017-09-15 at 11 05 13 am](https://user-images.githubusercontent.com/1861171/30496915-c6930040-9a05-11e7-96f9-643e8e9ca3c5.png)