### PR TITLE
secrets are now managed by puppet

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -9,7 +9,6 @@ set :deploy_to, '/opt/app/bento/bento'
 
 set :linked_files, fetch(:linked_files, []).push(
   'config/database.yml',
-  'config/secrets.yml',
   'config/honeybadger.yml'
 )
 


### PR DESCRIPTION
This PR removes the `config/secrets.yml` files from shared_configs as puppet now manages this data (via the `SECRET_KEY_BASE` environment variable that the checked in version of `config/secrets.yml` uses for production). See https://github.com/sul-dlss/operations-tasks/issues/778 for discussion

Requires the following PRs to be merged:

- https://github.com/sul-dlss/shared_configs/pull/381
- https://github.com/sul-dlss/shared_configs/pull/382