### PR TITLE
override HighlightedFacetItem to handle website facet queries

### DIFF
--- a/app/services/abstract_search_service.rb
+++ b/app/services/abstract_search_service.rb
@@ -13,7 +13,8 @@
 #
 class AbstractSearchService
   class NoResults < StandardError; end
-
+  class HighlightedFacetItem; end
+  
   class Request
     def initialize(search_terms, max_results = Settings.MAX_RESULTS)
       @search_terms = search_terms.respond_to?(:join) ? search_terms.join(' ') : search_terms
@@ -39,6 +40,7 @@ class AbstractSearchService
   # Various methods or constants will need to be overriden in order for the subclassed response class to work properly
   class Response
     HIGHLIGHTED_FACET_FIELD = nil
+    HIGHLIGHTED_FACET_CLASS = AbstractSearchService::HighlightedFacetItem
     QUERY_URL = nil
 
     attr_reader :body
@@ -68,7 +70,7 @@ class AbstractSearchService
       return [] unless defined?(self.class::HIGHLIGHTED_FACET_FIELD) && defined?(self.class::QUERY_URL)
 
       sorted_highlighted_facet_values.take(count).map do |facet_hash|
-        HighlightedFacetItem.new(facet_hash, self.class::HIGHLIGHTED_FACET_FIELD, self.class::QUERY_URL)
+        self.class::HIGHLIGHTED_FACET_CLASS.new(facet_hash, self.class::HIGHLIGHTED_FACET_FIELD, self.class::QUERY_URL)
       end
     end
 

--- a/spec/fixtures/library.stanford.edu/2.html
+++ b/spec/fixtures/library.stanford.edu/2.html
@@ -1,0 +1,507 @@
+﻿<!DOCTYPE html>
+<!--[if lt IE 7]>      <html lang="en" class="lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html lang="en" class="lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html lang="en" class="lt-ie9" > <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en"> <!--<![endif]-->
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Library website search | Stanford Libraries</title>
+  
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta property="og:site_name" content="Stanford Libraries" />
+<meta property="og:url" content="https://library.stanford.edu/search/website" />
+<link rel="shortcut icon" href="https://library.stanford.edu/sites/all/themes/sulair2016/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta property="og:title" content="Library website search" />
+<meta property="og:type" content="article" />
+<meta name="generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="canonical" href="https://library.stanford.edu/search/website" />
+<link rel="shortlink" href="https://library.stanford.edu/search/website" />
+  <link rel="dns-prefetch" href="//fonts.googleapis.com">
+
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700">
+  <link type="text/css" rel="stylesheet" href="https://library.stanford.edu/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://library.stanford.edu/sites/default/files/css/css_qIeN9fqTub3E8wdAtkVKjy6Js4UpXI4GgCnK4s_oyIQ.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://library.stanford.edu/sites/default/files/css/css_KIgRPkIGJa25MFFfgkS9P5Wgl2f_ySXgt4R56-zIxOM.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://library.stanford.edu/sites/default/files/css/css_B4YJ3YfZEMX3x7tx-ICpwUs2foqFx8izNbIwng7nQkg.css" media="screen" />
+
+</head>
+<body class="html not-front not-logged-in no-sidebars page-search page-search-website role-id-1 role-anonymous-user user-uid-0" >
+  <div id="skip-link" class="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    
+  <div id="site-wrapper" class="site-wrapper"><div id="site" class="site">
+    <header id="site-header" class="site-header">
+              <div class="site-top-bar">
+          <div class="layout-container">
+            <h2 class="element-invisible">Secondary menu</h2><ul id="secondary-menu-links" class="secondary-menu menu"><li class="menu-968 first"><a href="http://library.stanford.edu/myaccount">My Account</a></li>
+<li class="menu-4838 last"><a href="/ask/email/feedback?source=search/website">Feedback</a></li>
+</ul>
+                          <section class="site-feedback">
+                  <div class="region region-feedback">
+    <div id="block-webform-client-block-245" class="block block-webform block-webform-client-block-245">
+
+      
+  <div class="content">
+    <form class="webform-client-form" enctype="multipart/form-data" action="/ask/email/feedback?search=books" method="post" id="webform-client-form-245" accept-charset="UTF-8"><div><div class="form-item webform-component webform-component-textfield" id="webform-component-subject">
+  <label for="edit-submitted-subject">Subject <span class="form-required" title="This field is required.">*</span></label>
+ <input type="text" id="edit-submitted-subject" name="submitted[subject]" value="" size="60" maxlength="128" class="form-text required" />
+ <div class="description">In a few words, what is your feedback about?</div>
+</div>
+<div class="form-item webform-component webform-component-textarea" id="webform-component-feedback">
+  <label for="edit-submitted-feedback">Message <span class="form-required" title="This field is required.">*</span></label>
+ <div class="form-textarea-wrapper resizable"><textarea id="edit-submitted-feedback" name="submitted[feedback]" cols="60" rows="5" class="form-textarea required"></textarea></div>
+</div>
+<div class="form-item webform-component webform-component-textfield webform-container-inline" id="webform-component-name">
+  <label for="edit-submitted-name">Your name <span class="form-required" title="This field is required.">*</span></label>
+ <input type="text" id="edit-submitted-name" name="submitted[name]" value="" size="60" maxlength="128" class="form-text required" />
+</div>
+<div class="form-item webform-component webform-component-email webform-container-inline" id="webform-component-email">
+  <label for="edit-submitted-email">Your email <span class="form-required" title="This field is required.">*</span></label>
+ <input class="email form-text form-email required" type="email" id="edit-submitted-email" name="submitted[email]" size="60" />
+</div>
+<input type="hidden" name="submitted[source]" value="" />
+<input type="hidden" name="details[sid]" />
+<input type="hidden" name="details[page_num]" value="1" />
+<input type="hidden" name="details[page_count]" value="1" />
+<input type="hidden" name="details[finished]" value="0" />
+<input type="hidden" name="form_build_id" value="form-vIjpGjT6psCB6CKP54c5CH6VRxyG9QwrDnfqiehUaLY" />
+<input type="hidden" name="form_id" value="webform_client_form_245" />
+<div class="form-item form-type-textfield form-item-email-address-check">
+  <label for="edit-email-address-check">Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent. </label>
+ <input autocomplete="off" tabindex="-1" type="text" id="edit-email-address-check" name="email_address_check" value="" size="60" maxlength="128" class="form-text" />
+</div>
+<div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit--2" name="op" value="Send" class="form-submit" /></div></div></form>  </div>
+</div>
+  </div>
+              </section>
+                      </div>
+        </div>
+      
+      <div class="layout-container">
+        <button class="nav-toggle js-nav-toggle">
+          <span class="nav-toggle-text">Menu</span>
+          <span class="nav-toggle-icon">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+          </span>
+        </button>
+
+        <a href="/" class="site-title" id="logo" title="Stanford Libraries" rel="home">
+          <img src="/sites/all/themes/sulair2016/logo.svg" alt="Stanford Libraries" class="logo" />
+        </a>
+
+          <div class="region region-header">
+    <div id="block-search-form" class="block block-search block-search-form">
+
+      
+  <div class="content">
+    <form action="/search/website?search=books" method="post" id="search-block-form" accept-charset="UTF-8"><div>  <h2 class="element-invisible">Search form</h2>
+<div class="form-item form-type-textfield form-item-search-block-form">
+  <label class="element-invisible" for="edit-search-block-form--2">Search </label>
+ <input title="Enter the terms you wish to search for." type="text" id="edit-search-block-form--2" name="search_block_form" value="" size="15" maxlength="128" class="form-text" />
+</div>
+<div class="form-actions form-wrapper" id="edit-actions--2"><input type="submit" id="edit-submit--3" name="op" value="Search" class="form-submit" /><svg class="icon icon-search"><use xlink:href="#icon-search"></use></svg></div><input type="hidden" name="form_build_id" value="form-8R3D4pnmEmV7Izxj9ugmSow-XKqYvshVvIme_7qiIyI" />
+<input type="hidden" name="form_id" value="search_block_form" />
+</div></form>  </div>
+</div>
+  </div>
+      </div>
+
+              <nav id="navigation" class="site-navigation"><div class="layout-container">
+          <ul class="menu"><li class="first expanded"><a href="/about" title="The basics: library hours, people &amp; contacts, news &amp; events">About</a><ul class="menu"><li class="first leaf"><a href="/people">People</a></li>
+<li class="leaf"><a href="https://library-hours.stanford.edu">Hours</a></li>
+<li class="leaf"><a href="/blogs">Blogs</a></li>
+<li class="leaf"><a href="/today">Events, exhibits, workshops</a></li>
+<li class="leaf"><a href="/news">News</a></li>
+<li class="leaf"><a href="/contacts">Departments &amp; contacts</a></li>
+<li class="leaf"><a href="/department/library-communications-and-development">Support the Libraries</a></li>
+<li class="leaf"><a href="/using/employment-opportunities">Jobs</a></li>
+<li class="last leaf"><a href="/using/tours">Orientation tours</a></li>
+</ul></li>
+<li class="expanded"><a href="/libraries" class="menu-item--libraries">Libraries</a><ul class="menu"><li class="first leaf"><a href="/libraries/ars/about" class="menu-node-unpublished">Archive of Recorded Sound</a></li>
+<li class="leaf"><a href="/libraries/art/about" class="menu-node-unpublished">Art &amp; Architecture (Bowes)</a></li>
+<li class="leaf"><a href="/libraries/business/about" class="menu-node-unpublished">Business</a></li>
+<li class="leaf"><a href="/libraries/classics-library/about">Classics</a></li>
+<li class="leaf"><a href="/libraries/rumsey/about">David Rumsey Map Center</a></li>
+<li class="leaf"><a href="/libraries/branner/about" class="menu-node-unpublished">Earth Sciences (Branner)</a></li>
+<li class="leaf"><a href="/libraries/eal/about" class="menu-node-unpublished">East Asia</a></li>
+<li class="leaf"><a href="/libraries/cubberley/about" class="menu-node-unpublished">Education (Cubberley)</a></li>
+<li class="leaf"><a href="/libraries/englib/about" class="menu-node-unpublished">Engineering (Terman)</a></li>
+<li class="leaf"><a href="/libraries/green/about" class="menu-node-unpublished">Green</a></li>
+<li class="leaf"><a href="/libraries/hoover/about" class="menu-node-unpublished">Hoover</a></li>
+<li class="leaf"><a href="/libraries/hila/about" class="menu-node-unpublished">Hoover Archives</a></li>
+<li class="leaf"><a href="/libraries/lathrop/about" class="menu-node-unpublished">Lathrop</a></li>
+<li class="leaf"><a href="/libraries/law/about" class="menu-node-unpublished">Law (Crown)</a></li>
+<li class="leaf"><a href="/libraries/hopkins/about" class="menu-node-unpublished">Marine Biology (Miller)</a></li>
+<li class="leaf"><a href="/libraries/lane/about" class="menu-node-unpublished">Medical (Lane)</a></li>
+<li class="leaf"><a href="/libraries/music/about" class="menu-node-unpublished">Music</a></li>
+<li class="leaf"><a href="/libraries/philosophy/about" class="menu-node-unpublished">Philosophy (Tanner)</a></li>
+<li class="leaf"><a href="/libraries/sal/about" class="menu-node-unpublished">SAL1&amp;2</a></li>
+<li class="leaf"><a href="/libraries/sal3/about" class="menu-node-unpublished">SAL3</a></li>
+<li class="leaf"><a href="/libraries/newark/about" class="menu-node-unpublished">SAL Newark</a></li>
+<li class="leaf"><a href="/libraries/science/about">Science (Li and Ma)</a></li>
+<li class="leaf"><a href="/libraries/slac/about" class="menu-node-unpublished">SLAC</a></li>
+<li class="last leaf"><a href="/libraries/spc/about" class="menu-node-unpublished">Special Collections</a></li>
+</ul></li>
+<li class="expanded"><a href="/using">Using the libraries</a><ul class="menu"><li class="first leaf"><a href="/using/access-and-privileges" class="menu-node-unpublished">Access &amp; privileges</a></li>
+<li class="leaf"><a href="/using/borrow-renew-return" class="menu-node-unpublished">Borrow, renew, return</a></li>
+<li class="leaf"><a href="/using/connecting-e-resources" class="menu-node-unpublished">Connect to e-resources</a></li>
+<li class="leaf"><a href="https://searchworks.stanford.edu/reserves">Course reserves (SearchWorks)</a></li>
+<li class="leaf"><a href="/using/interlibrary-borrowing" class="menu-node-unpublished">Interlibrary borrowing</a></li>
+<li class="leaf"><a href="https://library-hours.stanford.edu">Hours</a></li>
+<li class="leaf"><a href="/using/print-copy-scan" class="menu-node-unpublished">Print, copy, scan</a></li>
+<li class="leaf"><a href="/using/equipment">Equipment</a></li>
+<li class="leaf"><a href="/using/study">Places to study</a></li>
+<li class="leaf"><a href="/using/accessibility">Access for persons with limited mobility</a></li>
+<li class="last leaf"><a href="/using/special-policies">Special policies</a></li>
+</ul></li>
+<li class="expanded"><a href="/collections">Collections</a><ul class="menu"><li class="first leaf"><a href="/areas" title="">Collecting areas</a></li>
+<li class="leaf"><a href="/notable-collections">Notable collections</a></li>
+<li class="leaf"><a href="https://searchworks.stanford.edu/catalog?f%5Bcollection_type%5D%5B%5D=Digital+Collection">Digital collections (SearchWorks)</a></li>
+<li class="last leaf"><a href="https://exhibits.stanford.edu/">Online exhibits</a></li>
+</ul></li>
+<li class="expanded"><a href="/research">Research support</a><ul class="menu"><li class="first leaf"><a href="/research-services">Research services</a></li>
+<li class="leaf"><a href="/faculty">... for faculty</a></li>
+<li class="leaf"><a href="/students">... for students</a></li>
+<li class="leaf"><a href="/search-tools">Search tools</a></li>
+<li class="leaf"><a href="/people/specialists">Specialists</a></li>
+<li class="leaf"><a href="/guides/topic">Topic guides</a></li>
+<li class="leaf"><a href="/guides/course">Course guides</a></li>
+<li class="leaf"><a href="/projects">Projects &amp; innovations</a></li>
+<li class="leaf"><a href="/workshops">Workshops</a></li>
+<li class="last leaf"><a href="/using/copyright-reminder">Copyright reminder</a></li>
+</ul></li>
+<li class="last expanded"><a href="/ask">Ask us</a><ul class="menu"><li class="first leaf"><a href="/ask/email/reference">Ask a reference question</a></li>
+<li class="leaf"><a href="/ask/email/feedback?source=search/website">Give us feedback</a></li>
+<li class="leaf"><a href="/ask/email/connection-problems">Report a connection problem</a></li>
+<li class="last leaf"><a href="https://web.stanford.edu/group/dlss/requestform/suggestpurchase.fb">Suggest a purchase (requires SUNet login)</a></li>
+</ul></li>
+</ul>        </div></nav> <!-- /.section, /#navigation -->
+          </header> <!-- /.section, /#header -->
+
+    
+    <div class="messages-wrapper">
+      <div class="layout-container">
+              </div>
+    </div>
+
+    <div id="main-wrapper" class="main-wrapper">
+      <main id="main" class="main">
+        <div class="layout-container clearfix">
+                      <div id="breadcrumb"><h2 class="element-invisible">You are here</h2><div class="breadcrumb"><span class="inline odd first"><a href="/">Home</a></span> <span class="delimiter">»</span> <span class="inline even last">books</span></div></div>
+          
+          
+                    <h1 class="page-title" id="page-title">Library website search</h1>                    <div class="tabs"></div>                    
+          
+          <div id="content" class="layout-content">
+            <a id="main-content"></a>
+              <div class="region region-content">
+    <div id="block-system-main" class="block block-system block-system-main">
+
+      
+  <div class="content">
+    <div class="panel-2col-stacked clearfix panel-display" >
+      <div class="panel-col-top panel-panel">
+      <div class="inside"><div class="panel-pane pane-search-box  search-box-pane"  >
+  <div class="panel-pane-inside">
+    
+            
+    
+    <div class="pane-content">
+      <div class="search-header"></div><form action="/search/website?search=books" method="post" id="sulair-search-website-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-keys">
+  <label class="element-invisible" for="edit-keys">Search Website </label>
+ <input class="search-input form-text" type="text" id="edit-keys" name="keys" value="books" size="60" maxlength="128" />
+</div>
+<input type="submit" id="edit-submit" name="op" value="Search" class="form-submit" /><input type="hidden" name="form_build_id" value="form-tnWexfV3EJrFl-D9ZI0kvTVBHwmSwudj5XvmXHVROkg" />
+<input type="hidden" name="form_id" value="sulair_search_website_form" />
+</div></form><div class="search-body"></div>    </div>
+
+    
+      </div>
+</div>
+</div>
+    </div>
+  
+  <div class="center-wrapper">
+    <div class="panel-col-first panel-panel">
+      <div class="inside"><div class="panel-pane pane-views-panes pane-sulair-search-panel-pane-1"  >
+  <div class="panel-pane-inside">
+    
+              <h2 class="pane-title">
+        Library website      </h2>
+        
+    
+    <div class="pane-content">
+      <div class="view view-sulair-search view-id-sulair_search view-display-id-panel_pane_1 view-dom-id-7f4e93cb1d9d8def430b12d6a68c4e52">
+          
+  
+  
+  
+      <div class="view-content">
+      <div class="item-list">    <ol class="search-results">          <li class="views-row views-row-1 views-row-odd views-row-first">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/metadata-department/services/new-record-or-record-change-requests/books">Books</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">Document for new record and record change requests for books for Metadata Department, Stanford University Libraries</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="/contacts">Department</a> &rsaquo; <a href="https://library.stanford.edu/department/metadata-department">Metadata Department</a></div>
+</li>
+          <li class="views-row views-row-2 views-row-even">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/spc/exhibits/past-exhibits/beasts-books">Beasts &amp; Books</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">Beasts &amp; Books
+</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="/libraries">Libraries</a> &rsaquo; <a href="https://library.stanford.edu/spc">Special Collections</a></div>
+</li>
+          <li class="views-row views-row-3 views-row-odd">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/guides/artists-books">Artists&#039; books</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">This guide is designed to provide an introduction to the literature of artists' books and to present a selection of artists' book holdings in the...</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="/guides">Guides</a></div>
+</li>
+          <li class="views-row views-row-4 views-row-even">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/africa-south-sahara/browse-topic/book-dealers">Book dealers</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">Africa south of the Sahara: Selected Internet resources for book dealers.</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="https://library.stanford.edu/africa-south-sahara">Africa South of the Sahara</a></div>
+</li>
+          <li class="views-row views-row-5 views-row-odd">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/africa-south-sahara/browse-topic/book-donations">Book donations</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">Africa south of the Sahara: Selected Internet resources about book donations.</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="https://library.stanford.edu/africa-south-sahara">Africa South of the Sahara</a></div>
+</li>
+          <li class="views-row views-row-6 views-row-even">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/guides/alphabet-books">Alphabet books</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">This guide lists alphabet books for children in Cubberley Education Library.
+</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="/guides">Guides</a></div>
+</li>
+          <li class="views-row views-row-7 views-row-odd">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/guides/counting-books">Counting books</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">This guide lists counting books for children in Cubberley Education Library.
+</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="/guides">Guides</a></div>
+</li>
+          <li class="views-row views-row-8 views-row-even">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/guides/find-books">Find books</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">This guide provides an overview of searching for books at Stanford.
+</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="/guides">Guides</a></div>
+</li>
+          <li class="views-row views-row-9 views-row-odd">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/guides/animal-books">Animal books</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">This guide lists nonfiction children's books and young adult literature in the Cubberley Education Library about animals.
+</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="/guides">Guides</a></div>
+</li>
+          <li class="views-row views-row-10 views-row-even views-row-last">  
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/projects/google-books">Google Books</a></span>  </div>  
+  <div class="views-field views-field-body-value">        <span class="field-content">Stanford is one of the libraries partnering with Google in this project to digitize, and make searchable, tens of millions of books.</span>  </div>
+
+<div class="result-breadcrumbs">
+  <span class="raquo"> &raquo; </span> <a href="/">Home</a> &rsaquo; <a href="/projects">Projects</a> &rsaquo; <a href="https://library.stanford.edu/projects/google-books">Google Books</a></div>
+</li>
+      </ol></div>    </div>
+  
+      <h2 class="element-invisible">Pages</h2><div class="item-list"><ul class="pager"><li class="pager-current first">1</li>
+<li class="pager-item"><a title="Go to page 2" href="/search/website?search=books&amp;page=1">2</a></li>
+<li class="pager-item"><a title="Go to page 3" href="/search/website?search=books&amp;page=2">3</a></li>
+<li class="pager-item"><a title="Go to page 4" href="/search/website?search=books&amp;page=3">4</a></li>
+<li class="pager-item"><a title="Go to page 5" href="/search/website?search=books&amp;page=4">5</a></li>
+<li class="pager-item"><a title="Go to page 6" href="/search/website?search=books&amp;page=5">6</a></li>
+<li class="pager-item"><a title="Go to page 7" href="/search/website?search=books&amp;page=6">7</a></li>
+<li class="pager-item"><a title="Go to page 8" href="/search/website?search=books&amp;page=7">8</a></li>
+<li class="pager-item"><a title="Go to page 9" href="/search/website?search=books&amp;page=8">9</a></li>
+<li class="pager-ellipsis">…</li>
+<li class="pager-next"><a title="Go to next page" href="/search/website?search=books&amp;page=1">next ›</a></li>
+<li class="pager-last last"><a title="Go to last page" href="/search/website?search=books&amp;page=265">last »</a></li>
+</ul></div>  
+  
+  
+  
+  
+</div>     </div>
+
+    
+      </div>
+</div>
+</div>
+    </div>
+    <div class="panel-col-last panel-panel">
+      <div class="inside"><div class="panel-pane pane-block pane-facetapi-shb0q1vwgcarrhrjhsztyhl2jaehijzw sidebar"  >
+  <div class="panel-pane-inside">
+    
+              <h2 class="pane-title">
+        Filter your results      </h2>
+        
+    
+    <div class="pane-content">
+      <div class="item-list"><ul class="facetapi-facetapi-links facetapi-facet-type" id="facetapi-facet-search-apinode-index-block-type--2"><li class="leaf first"><a href="/search/website?search=books&amp;f[0]=type%3Asite_microsite" rel="nofollow" class="facetapi-inactive">Group page (946)<span class="element-invisible">Apply Group page filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Alibrary_page" rel="nofollow" class="facetapi-inactive">Library microsite (566)<span class="element-invisible">Apply Library microsite filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Asubject" rel="nofollow" class="facetapi-inactive">Guide (341)<span class="element-invisible">Apply Guide filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Ablog" rel="nofollow" class="facetapi-inactive">Blog (269)<span class="element-invisible">Apply Blog filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Anews" rel="nofollow" class="facetapi-inactive">News (archived) (201)<span class="element-invisible">Apply News (archived) filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Abook" rel="nofollow" class="facetapi-inactive">Policy/Procedure (130)<span class="element-invisible">Apply Policy/Procedure filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Astanford_event" rel="nofollow" class="facetapi-inactive">Event/Workshop (62)<span class="element-invisible">Apply Event/Workshop filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Aperson" rel="nofollow" class="facetapi-inactive">Person (48)<span class="element-invisible">Apply Person filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Acollection" rel="nofollow" class="facetapi-inactive">Notable collection (47)<span class="element-invisible">Apply Notable collection filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Abranch" rel="nofollow" class="facetapi-inactive">Library hours &amp; access (11)<span class="element-invisible">Apply Library hours &amp; access filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Astanford_exhibition" rel="nofollow" class="facetapi-inactive">Exhibit (10)<span class="element-invisible">Apply Exhibit filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Aplace" rel="nofollow" class="facetapi-inactive">Location (9)<span class="element-invisible">Apply Location filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Asearch" rel="nofollow" class="facetapi-inactive">Search tool (7)<span class="element-invisible">Apply Search tool filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Aresearch" rel="nofollow" class="facetapi-inactive">Research service (3)<span class="element-invisible">Apply Research service filter</span></a></li>
+<li class="leaf"><a href="/search/website?search=books&amp;f[0]=type%3Acontact" rel="nofollow" class="facetapi-inactive">Contact (1)<span class="element-invisible">Apply Contact filter</span></a></li>
+<li class="leaf last"><a href="/search/website?search=books&amp;f[0]=type%3Asul_news" rel="nofollow" class="facetapi-inactive">News (1)<span class="element-invisible">Apply News filter</span></a></li>
+</ul></div>    </div>
+
+    
+      </div>
+</div>
+<div class="panel-separator"></div><div class="panel-pane pane-custom pane-1 sidebar"  >
+  <div class="panel-pane-inside">
+    
+              <h2 class="pane-title">
+        Need help? Ask us      </h2>
+        
+    
+    <div class="pane-content">
+      <ul><li>
+<a href="/ask/email/reference">Ask a reference question</a>
+</li>
+<li>
+<a href="/people/specialists">Find a specialist</a>
+</li>
+</ul>    </div>
+
+    
+      </div>
+</div>
+</div>
+    </div>
+  </div>
+
+  </div>
+  </div>
+</div>
+  </div>
+                      </div> <!-- /#content -->
+
+                  </div> <!-- /.layout-container -->
+      </main>
+    </div> <!-- /#main, /#main-wrapper -->
+
+    <footer role="contentinfo" id="footer" class="site-footer">
+      <div class="sul-footer">
+        <div class="layout-container">
+            <div class="region region-footer">
+    <div id="block-block-2" class="block block-block block-block-2">
+
+      
+  <div class="content">
+    <div class="sul-footer-img"><img alt="Stanford University Libraries" src="/sites/all/themes/sulair2016/assets/images/sul-logo-stacked.svg" height="45" /></div>
+<ul class="sul-footer-menu"><li><a href="http://library.stanford.edu">Stanford Libraries</a></li>
+  <li><a href="/hours">Hours</a></li>
+  <li><a href="/myaccount">My Account</a></li>
+  <li><a href="/ask">Ask us</a></li>
+  <li><a href="/opt-out">Opt out of analytics</a></li>
+  <li><a href="/sites/default/webauth/login?destination=front" class="staff-login js-staff-login">Staff login</a></li>
+</ul>  </div>
+</div>
+  </div>
+        </div>
+      </div>
+
+      <div class="copyright-footer">
+        <div class="layout-container clearfix">
+            <div class="region region-copyright-footer">
+    <div id="block-block-3" class="block block-block block-block-3">
+
+      
+  <div class="content">
+          <div id="bottom-logo" class="span2">
+        <a href="http://www.stanford.edu"><img src="https://www.stanford.edu/su-identity/images/footer-stanford-logo@2x.png" alt="Stanford University" width="105" height="49" /></a>
+      </div>
+      <!-- #bottom-logo end -->
+      <div id="bottom-text" class="span10">
+        <ul class="menu"><li class="menu-item home"><a href="http://www.stanford.edu">SU Home</a></li>
+          <li class="menu-item maps alt"><a href="http://visit.stanford.edu/plan/maps.html">Maps &amp; Directions</a></li>
+          <li class="menu-item search-stanford"><a href="http://www.stanford.edu/search/">Search Stanford</a></li>
+          <li class="menu-item terms alt"><a href="http://www.stanford.edu/site/terms.html">Terms of Use</a></li>
+          <li class="menu-item emergency-info"><a href="http://emergency.stanford.edu">Emergency Info</a></li>
+        </ul></div> <!-- .bottom-text end -->
+      <div class="clear"></div>
+      <p class="copyright vcard">© <span class="fn org">Stanford University</span>, <span class="adr"> <span class="locality">Stanford</span>, <span class="region">California</span> <span class="postal-code">94305</span></span>.  <span id="copyright-complaint"><a href="https://uit.stanford.edu/security/copyright-infringement" class="copyright-complaint">Copyright Complaints</a></span></p>  </div>
+</div>
+  </div>
+        </div>
+      </div>
+    </footer> <!-- /.section, /#footer -->
+
+  </div></div> <!-- /#page, /#site-wrapper -->
+  <script type="text/javascript" src="https://library.stanford.edu/misc/jquery.js?v=1.4.4"></script>
+<script type="text/javascript" src="https://library.stanford.edu/misc/jquery.once.js?v=1.2"></script>
+<script type="text/javascript" src="https://library.stanford.edu/misc/drupal.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/misc/jquery.cookie.js?v=1.0"></script>
+<script type="text/javascript" src="https://library.stanford.edu/misc/jquery.form.js?v=2.52"></script>
+<script type="text/javascript" src="https://library.stanford.edu/misc/ajax.js?v=7.52"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+document.createElement( "picture" );
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/custom/stanford_events_importer/js/stanford_event_nodes.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/custom/stanford_events_importer/js/stanford_events_calendar.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/custom/sulair/js/administration.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/lightbox2/js/auto_image_handling.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/lightbox2/js/lightbox.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/misc/progress.js?v=7.52"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/views_load_more/views_load_more.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/views/js/base.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/views/js/ajax_view.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/misc/textarea.js?v=7.52"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/facetapi/facetapi.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/webform/js/webform.js?os69v8"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/google_analytics/googleanalytics.js?os69v8"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","//www.google-analytics.com/analytics.js","ga");ga("create", "UA-7219229-14", {"cookieDomain":"auto"});ga('require', 'linkid');ga("send", "pageview");
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/themes/sulair2016/assets/js/main.js?os69v8"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"sulair2016","theme_token":"XK0kBJXh-QsN-9dWMCOPyBBF7FgFcw8ogP5fpbkvkPA","js":{"sites\/all\/modules\/contrib\/picture\/picturefill2\/picturefill.min.js":1,"sites\/all\/modules\/contrib\/picture\/picture.min.js":1,"\/\/libraryh3lp.com\/js\/libraryh3lp.js?multi,poll,popup":1,"misc\/jquery.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"misc\/jquery.cookie.js":1,"misc\/jquery.form.js":1,"misc\/ajax.js":1,"0":1,"sites\/all\/modules\/custom\/stanford_events_importer\/js\/stanford_event_nodes.js":1,"sites\/all\/modules\/custom\/stanford_events_importer\/js\/stanford_events_calendar.js":1,"sites\/all\/modules\/custom\/sulair\/js\/administration.js":1,"sites\/all\/modules\/contrib\/lightbox2\/js\/auto_image_handling.js":1,"sites\/all\/modules\/contrib\/lightbox2\/js\/lightbox.js":1,"misc\/progress.js":1,"sites\/all\/modules\/contrib\/views_load_more\/views_load_more.js":1,"sites\/all\/modules\/contrib\/views\/js\/base.js":1,"sites\/all\/modules\/contrib\/views\/js\/ajax_view.js":1,"misc\/textarea.js":1,"sites\/all\/modules\/contrib\/facetapi\/facetapi.js":1,"sites\/all\/modules\/contrib\/webform\/js\/webform.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"1":1,"sites\/all\/themes\/sulair2016\/assets\/js\/main.js":1},"css":{"modules\/system\/system.base.css":1,"modules\/comment\/comment.css":1,"sites\/all\/modules\/contrib\/date\/date_api\/date.css":1,"sites\/all\/modules\/contrib\/picture\/picture_wysiwyg.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/lightbox2\/css\/lightbox.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/modules\/contrib\/panels\/plugins\/layouts\/twocol_stacked\/twocol_stacked.css":1,"sites\/all\/modules\/contrib\/webform\/css\/webform.css":1,"sites\/all\/themes\/sulair2016\/assets\/css\/normalize.css":1,"sites\/all\/themes\/sulair2016\/assets\/css\/screen.css":1,"sites\/all\/themes\/sulair2016\/assets\/css\/shame.css":1}},"jcarousel":{"ajaxPath":"\/jcarousel\/ajax\/views"},"lightbox2":{"rtl":0,"file_path":"\/(\\w\\w\/)public:\/","default_image":"\/sites\/all\/modules\/contrib\/lightbox2\/images\/brokenimage.jpg","border_size":10,"font_color":"000","box_color":"fff","top_position":"","overlay_opacity":"0.8","overlay_color":"000","disable_close_click":1,"resize_sequence":0,"resize_speed":400,"fade_in_speed":400,"slide_down_speed":600,"use_alt_layout":0,"disable_resize":0,"disable_zoom":0,"force_show_nav":0,"show_caption":1,"loop_items":0,"node_link_text":"View Image Details","node_link_target":0,"image_count":"Image !current of !total","video_count":"Video !current of !total","page_count":"Page !current of !total","lite_press_x_close":"press \u003Ca href=\u0022#\u0022 onclick=\u0022hideLightbox(); return FALSE;\u0022\u003E\u003Ckbd\u003Ex\u003C\/kbd\u003E\u003C\/a\u003E to close","download_link_text":"","enable_login":false,"enable_contact":false,"keys_close":"c x 27","keys_previous":"p 37","keys_next":"n 39","keys_zoom":"z","keys_play_pause":"32","display_image_size":"original","image_node_sizes":"()","trigger_lightbox_classes":"","trigger_lightbox_group_classes":"","trigger_slideshow_classes":"","trigger_lightframe_classes":"","trigger_lightframe_group_classes":"","custom_class_handler":"lightbox_ungrouped","custom_trigger_classes":"img.lightbox-wysiwyg","disable_for_gallery_lists":1,"disable_for_acidfree_gallery_lists":true,"enable_acidfree_videos":true,"slideshow_interval":5000,"slideshow_automatic_start":0,"slideshow_automatic_exit":0,"show_play_pause":0,"pause_on_next_click":0,"pause_on_previous_click":0,"loop_slides":0,"iframe_width":600,"iframe_height":400,"iframe_border":1,"enable_video":0},"urlIsAjaxTrusted":{"\/search\/website":true,"\/search\/website?search=books":true,"\/ask\/email\/feedback?search=books":true},"views":{"ajax_path":"\/views\/ajax","ajaxViews":{"views_dom_id:7f4e93cb1d9d8def430b12d6a68c4e52":{"view_name":"sulair_search","view_display_id":"panel_pane_1","view_args":"","view_path":"search\/website","view_base_path":"search\/website","view_dom_id":"7f4e93cb1d9d8def430b12d6a68c4e52","pager_element":0}}},"facetapi":{"facets":[{"limit":20,"id":"facetapi-facet-search-apinode-index-block-type","searcher":"search_api@node_index","realmName":"block","facetName":"type","queryType":null,"widget":"facetapi_links"},{"limit":20,"id":"facetapi-facet-search-apinode-index-block-type--2","searcher":"search_api@node_index","realmName":"block","facetName":"type","queryType":null,"widget":"facetapi_links"}]},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip"}});
+//--><!]]>
+</script>
+    <div class="region region-page-bottom">
+    <script type="text/javascript">
+   (function() {
+       var mf = document.createElement("script"); mf.type = "text/javascript"; mf.async = true;
+       mf.src = "//cdn.mouseflow.com/projects/dd31473b-d667-4129-b968-22d78b1c69e3.js";
+       document.getElementsByTagName("head")[0].appendChild(mf);
+   })();
+</script>  </div>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/picture/picturefill2/picturefill.min.js?v=2.3.1"></script>
+<script type="text/javascript" src="https://library.stanford.edu/sites/all/modules/contrib/picture/picture.min.js?v=7.52"></script>
+<script type="text/javascript" src="//libraryh3lp.com/js/libraryh3lp.js?multi,poll,popup"></script>
+  <div style="display: none;">
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="a" d="M-9.334-3.334h42.667v42.667H-9.334z"/></defs><symbol id="icon-accessibility" viewBox="0 0 24 24"><path d="M22.448 20.19a.998.998 0 0 0-1.265-.632c-.375.125-.778.244-1.102.328a38.103 38.103 0 0 1-.263-1.144c-.52-2.366-.93-4.236-2.319-4.236-.869 0-5.415.874-7.659 1.313l-.448-3.131 4.85-1.212a1 1 0 0 0-.485-1.94l-4.648 1.162-.502-3.505a3.731 3.731 0 0 0 2.348-3.46A3.733 3.733 0 0 0 7.226.005 3.733 3.733 0 0 0 3.5 3.733a3.73 3.73 0 0 0 3.119 3.674l.538 3.771c-2.622.781-4.657 3.473-4.657 6.328 0 3.585 2.871 6.5 6.4 6.5 3.577 0 6.6-2.976 6.6-6.5v-.708a40.839 40.839 0 0 1 1.659-.262c.252.564.541 1.88.707 2.636.414 1.887.622 2.834 1.634 2.834.598 0 1.818-.385 2.316-.551a1 1 0 0 0 .632-1.265zM5.5 3.733a1.73 1.73 0 0 1 1.727-1.728c.953 0 1.729.776 1.729 1.728a1.73 1.73 0 0 1-3.456 0zm8 13.773c0 2.398-2.149 4.5-4.6 4.5-2.386 0-4.4-2.06-4.4-4.5 0-2.028 1.418-3.71 2.945-4.313l.564 3.954a1 1 0 0 0 1.186.839c1.445-.289 2.963-.582 4.304-.83v.35z"/></symbol><symbol id="icon-accessprivs" viewBox="0 0 24 24"><path d="M0 10h24v12.5a.5.5 0 0 1-.5.5H.5a.5.5 0 0 1-.5-.5V10zm13 3h4v-1h-4v1zm0 2h8v-1h-8v1zm0 2h8v-1h-8v1zm0 2h8v-1h-8v1zM3 20h8v-.5c0-1.24-.623-2.638-2.249-3.22A2.491 2.491 0 0 0 9.5 14.5C9.5 13.122 8.378 12 7 12s-2.5 1.122-2.5 2.5c0 .697.288 1.326.749 1.78C3.623 16.862 3 18.26 3 19.5v.5zM24 5.5V9H0V5.5A.5.5 0 0 1 .5 5H9V4c0-1.654 1.346-3 3-3s3 1.346 3 3v1h8.5a.5.5 0 0 1 .5.5zM13 4a1 1 0 1 0-2 0 1 1 0 0 0 2 0z"/></symbol><symbol id="icon-arrow-circle-right" viewBox="0 0 1792 1792"><path d="M1413 896q0-27-18-45l-91-91-362-362q-18-18-45-18t-45 18l-91 91q-18 18-18 45t18 45l189 189H448q-26 0-45 19t-19 45v128q0 26 19 45t45 19h502l-189 189q-19 19-19 45t19 45l91 91q18 18 45 18t45-18l362-362 91-91q18-18 18-45zm251 0q0 209-103 385.5T1281.5 1561 896 1664t-385.5-103T231 1281.5 128 896t103-385.5T510.5 231 896 128t385.5 103T1561 510.5 1664 896z"/></symbol><symbol id="icon-askus-chat" viewBox="0 0 24 24"><path d="M11.997.903c-6.617 0-12 4.434-12 9.883 0 2.573 1.177 4.985 3.325 6.831l-2.41 4.812a.497.497 0 0 0 .447.723.491.491 0 0 0 .211-.047l6.437-2.995c1.278.37 2.619.558 3.99.558 6.617 0 12-4.433 12-9.882s-5.384-9.883-12-9.883z"/></symbol><symbol id="icon-askus-librarian" viewBox="0 0 24 24"><g fill="#010101"><path d="M9.059 24h5.882l.875-7H8.184zM7.024 14h9.957l.141-.234.03-.06C17.69 12.448 18 10.915 18 9.5V9H6v.5c0 1.416.309 2.948.848 4.206l.176.294zM21.5 15h-19a.5.5 0 0 0 0 1h19a.5.5 0 0 0 0-1zM12 8c2.205 0 4-1.794 4-4 0-2.205-1.795-4-4-4-2.206 0-4 1.795-4 4 0 2.206 1.794 4 4 4z"/></g></symbol><symbol id="icon-bars" viewBox="0 0 1792 1792"><path d="M1664 1344v128q0 26-19 45t-45 19H192q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45zm0-512v128q0 26-19 45t-45 19H192q-26 0-45-19t-19-45V832q0-26 19-45t45-19h1408q26 0 45 19t19 45zm0-512v128q0 26-19 45t-45 19H192q-26 0-45-19t-19-45V320q0-26 19-45t45-19h1408q26 0 45 19t19 45z"/></symbol><symbol id="icon-blogs" viewBox="0 0 24 24"><path d="M23.5 11H9.229l-4.422 3.439a.502.502 0 0 1-.527.054.499.499 0 0 1-.28-.448V11H.5a.5.5 0 0 0-.5.5v7a.5.5 0 0 0 .5.5h13.31l4.357 3.874a.503.503 0 0 0 .538.082A.5.5 0 0 0 19 22.5V19h4.5a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.5-.5z"/><path d="M23.5 0H.5a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5H5v4.022l5.036-3.917v-.001L10.172 9H23.5a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5z"/></symbol><symbol id="icon-close" viewBox="0 0 1792 1792"><path d="M1490 1322q0 40-28 68l-136 136q-28 28-68 28t-68-28l-294-294-294 294q-28 28-68 28t-68-28l-136-136q-28-28-28-68t28-68l294-294-294-294q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 294 294-294q28-28 68-28t68 28l136 136q28 28 28 68t-28 68l-294 294 294 294q28 28 28 68z"/></symbol><symbol id="icon-coffee" viewBox="0 0 24 24"><path d="M6.501 23.533A.5.5 0 0 0 7 24h10a.5.5 0 0 0 .499-.467L18.4 10H5.599l.902 13.533zm.134-11.374A.499.499 0 0 1 7 12c1.723 0 3.233 1.402 3.233 3 0 1.683-1.274 3-2.9 3a.5.5 0 0 1-.499-.467l-.333-5a.495.495 0 0 1 .134-.374zM19.5 5H6.76L3.409.214 2.59.787 5.539 5H4.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5z"/></symbol><symbol id="icon-computer" viewBox="0 0 24 24"><path d="M22 1H2C.896 1 0 1.897 0 3v15c0 1.103.896 2 2 2h6.807l-.667 2H5a.5.5 0 0 0 0 1h14a.5.5 0 0 0 0-1h-3.141l-.666-2H22c1.103 0 2-.897 2-2V3c0-1.103-.897-2-2-2zM12 18.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2zM22 16H2V3h20v13z"/></symbol><symbol id="icon-computersul" viewBox="0 0 24 24"><path fill="#010101" d="M22 .863H2c-1.104 0-2 .897-2 2v15c0 1.102.896 2 2 2h6.807l-.667 2H5a.5.5 0 1 0 0 1h14a.5.5 0 0 0 0-1h-3.141l-.666-2H22c1.103 0 2-.898 2-2v-15c0-1.103-.897-2-2-2zm-10 17.5a1.001 1.001 0 0 1 0-2 1 1 0 0 1 0 2zm10-2.5H2v-13h20v13z"/><path fill="#010101" d="M16.5 7.029h-1v-.498c0-1.93-1.57-3.5-3.5-3.5s-3.5 1.57-3.5 3.5v.498h-1a.5.5 0 0 0-.5.5v7a.5.5 0 0 0 .5.5h9a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.5-.5zm-4 3.846v1.654a.5.5 0 1 1-1 0v-1.654a.985.985 0 0 1-.5-.846c0-.551.449-1 1-1s1 .449 1 1a.985.985 0 0 1-.5.846zm2-3.846h-5v-.498c0-1.378 1.122-2.5 2.5-2.5 1.379 0 2.5 1.122 2.5 2.5v.498z"/></symbol><symbol id="icon-contacts" viewBox="0 0 24 24"><path d="M21.5 3H19V1.5a.5.5 0 0 0-.5-.5h-15a.5.5 0 0 0-.5.5v2h1.5a1.001 1.001 0 0 1 0 2H3v1h1.5a1.001 1.001 0 0 1 0 2H3v1h1.5a1.001 1.001 0 0 1 0 2H3v1h1.5a1.001 1.001 0 0 1 0 2H3v1h1.5a1.001 1.001 0 0 1 0 2H3v1h1.5a1.001 1.001 0 0 1 0 2H3v2a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5V20h2.5a.5.5 0 0 0 .5-.5v-16a.5.5 0 0 0-.5-.5zM15 9.5a.5.5 0 0 1-.5.5h-6a.5.5 0 0 1-.5-.5v-4a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 .5.5v4zm6 9.5h-2v-3h2v3zm0-4h-2v-3h2v3zm0-4h-2V8h2v3zm0-4h-2V4h2v3z"/><path d="M2.5 5h2c.275 0 .5-.225.5-.5S4.775 4 4.5 4h-2a.5.5 0 0 0 0 1zM2.5 8h2c.275 0 .5-.225.5-.5S4.775 7 4.5 7h-2a.5.5 0 0 0 0 1zM2.5 11h2c.275 0 .5-.225.5-.5s-.225-.5-.5-.5h-2a.5.5 0 0 0 0 1zM2.5 14h2c.275 0 .5-.225.5-.5s-.225-.5-.5-.5h-2a.5.5 0 0 0 0 1zM2.5 17h2c.275 0 .5-.225.5-.5s-.225-.5-.5-.5h-2a.5.5 0 0 0 0 1zM5 19.5c0-.275-.225-.5-.5-.5h-2a.5.5 0 0 0 0 1h2c.275 0 .5-.225.5-.5z"/></symbol><symbol id="icon-conversation" viewBox="0 0 24 24"><path d="M16.5 8.75c.476 0 .941.045 1.399.115.065-.379.101-.771.101-1.18C18 3.585 13.962.25 9 .25c-4.963 0-9 3.335-9 7.435 0 1.962.855 3.826 2.36 5.178l-1.794 3.14a.5.5 0 0 0 .62.712l4.839-1.937c.435.124.887.218 1.348.281.022.002.065-.005.075.004.075 0 .319-.002.678-.022.679-3.514 4.233-6.291 8.374-6.291z"/><path d="M16.5 9.75c-4.065 0-7.5 2.977-7.5 6.5 0 3.355 2.878 6.224 6.434 6.572l.006.002a7.581 7.581 0 0 0 3.572-.536l3.813 1.43a.498.498 0 0 0 .623-.691l-1.325-2.65C23.327 19.289 24 17.868 24 16.25c0-3.523-3.435-6.5-7.5-6.5z"/></symbol><symbol id="icon-copier" viewBox="0 0 24 24"><path d="M16 5.5a.5.5 0 0 0-.5-.5H2.451l7.29-3.999A.5.5 0 0 0 9.26.124l-9 4.938A.55.55 0 0 0 0 5.5V9h16V5.5zM2.5 8a.5.5 0 1 1 .002-1.002A.5.5 0 0 1 2.5 8z"/><path d="M21.888 15.162L16 19.564V13.75l6.487-4.85a.5.5 0 1 0-.599-.801L16 12.502V10H0v12.5a.5.5 0 0 0 .5.5H1v.5a.5.5 0 0 0 1 0V23h12v.5a.5.5 0 0 0 1 0V23h.5a.5.5 0 0 0 .5-.5v-1.687l6.487-4.85a.5.5 0 1 0-.599-.801zM14 20.5a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 .5.5v3zm0-6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 .5.5v3z"/></symbol><symbol id="icon-electricaloutlet" viewBox="0 0 24 24"><path d="M20.5 2h-17C1.227 2 0 7.152 0 12s1.227 10 3.5 10h17c2.273 0 3.5-5.152 3.5-10S22.773 2 20.5 2zM8 11.5a.5.5 0 0 1-1 0v-5a.5.5 0 0 1 1 0v5zm6.5 7a.5.5 0 0 1-.5.5h-4a.5.5 0 0 1-.5-.5v-3c0-1.378 1.121-2.5 2.5-2.5 1.378 0 2.5 1.122 2.5 2.5v3zm2.5-7a.5.5 0 0 1-1 0v-5a.5.5 0 0 1 1 0v5z"/></symbol><symbol id="icon-events" viewBox="0 0 24 24"><path d="M12 16h4v3h-4zM7 16h4v3H7zM12 12h4v3h-4zM7 12h4v3H7z"/><path d="M0 23.5a.5.5 0 0 0 .5.5h23a.5.5 0 0 0 .5-.5V8H0v15.5zM2.5 16a.5.5 0 0 1 0-1H6v-3H2.5a.5.5 0 0 1 0-1H6V9.5a.5.5 0 0 1 1 0V11h4V9.5a.5.5 0 0 1 1 0V11h4V9.5a.5.5 0 0 1 1 0V11h4.5a.5.5 0 0 1 0 1H17v3h4.5a.5.5 0 0 1 0 1H17v3h4.5a.5.5 0 0 1 0 1H17v1.5a.5.5 0 0 1-1 0V20h-4v1.5a.5.5 0 0 1-1 0V20H7v1.5a.5.5 0 0 1-1 0V20H2.5a.5.5 0 0 1 0-1H6v-3H2.5zM23.5 2H20V.5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5V2H8V.5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5V2H.5a.5.5 0 0 0-.5.5V7h24V2.5a.5.5 0 0 0-.5-.5zM7 4H5V1h2v3zm12 0h-2V1h2v3z"/></symbol><symbol id="icon-external-link" viewBox="0 0 1792 1792"><path d="M1408 928v320q0 119-84.5 203.5T1120 1536H288q-119 0-203.5-84.5T0 1248V416q0-119 84.5-203.5T288 128h704q14 0 23 9t9 23v64q0 14-9 23t-23 9H288q-66 0-113 47t-47 113v832q0 66 47 113t113 47h832q66 0 113-47t47-113V928q0-14 9-23t23-9h64q14 0 23 9t9 23zm384-864v512q0 26-19 45t-45 19-45-19l-176-176-652 652q-10 10-23 10t-23-10L695 983q-10-10-10-23t10-23l652-652-176-176q-19-19-19-45t19-45 45-19h512q26 0 45 19t19 45z"/></symbol><symbol id="icon-facebook-circle" viewBox="0 0 24 24"><path d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm3.595 11.5H13.5v7h-3v-7h-2v-2h2V8.336c0-1.1.352-2.819 2.649-2.819l2.351.007V7.83h-1.408c-.244 0-.592.124-.592.647V9.5h2.339l-.244 2z"/></symbol><symbol id="icon-groupstudy" viewBox="0 0 24 24"><path d="M23.998 20.359a4.5 4.5 0 0 0-2.697-3.967 2.986 2.986 0 0 0 1.2-2.384c0-1.655-1.346-3-3-3s-3 1.345-3 3a2.99 2.99 0 0 0 1.197 2.383 4.518 4.518 0 0 0-2.46 2.698 5.564 5.564 0 0 1 1.644 1.912h6.639a.494.494 0 0 0 .477-.642zM8.763 19.071a4.528 4.528 0 0 0-2.462-2.679 2.986 2.986 0 0 0 1.2-2.384c0-1.655-1.346-3-3-3s-3 1.345-3 3a2.99 2.99 0 0 0 1.197 2.383A4.5 4.5 0 0 0 0 20.507c0 .276.224.5.5.493h6.607a5.577 5.577 0 0 1 1.656-1.929z"/><path d="M16.498 23.359a4.5 4.5 0 0 0-2.697-3.967 2.986 2.986 0 0 0 1.2-2.384c0-1.655-1.346-3-3-3s-3 1.345-3 3c0 .975.475 1.835 1.197 2.383A4.5 4.5 0 0 0 7.5 23.507c0 .277.224.493.5.493h8.02a.494.494 0 0 0 .478-.641zM17.5 0h-11C5.673 0 5 .666 5 1.493v7c0 .827.673 1.5 1.5 1.5h.793l2.853 2.853a.5.5 0 0 0 .854-.353v-2.5h6.5c.827 0 1.5-.673 1.5-1.5v-7C19 .666 18.327 0 17.5 0zm-2.031 7H8.5a.506.506 0 0 1-.5-.507.5.5 0 0 1 .5-.5h6.969a.5.5 0 0 1 .5.5.506.506 0 0 1-.5.507zm0-2H8.5a.506.506 0 0 1-.5-.507.5.5 0 0 1 .5-.5h6.969a.5.5 0 0 1 .5.5.506.506 0 0 1-.5.507zm0-2H8.5c-.276 0-.5-.23-.5-.507a.5.5 0 0 1 .5-.5h6.969a.5.5 0 0 1 .5.5.506.506 0 0 1-.5.507z"/></symbol><symbol id="icon-hours" viewBox="0 0 24 24"><path d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm6.354 18.354a.5.5 0 0 1-.707 0l-4.638-4.637A1.973 1.973 0 0 1 12 14c-1.103 0-2-.896-2-2 0-.737.405-1.375 1-1.722V6.5a.5.5 0 0 1 1 0V10c1.103 0 2 .896 2 2 0 .37-.108.713-.284 1.011l4.637 4.636a.5.5 0 0 1 .001.707z"/></symbol><symbol id="icon-individual" viewBox="0 0 24 24"><path d="M12.005 10.26l-1.39-1.179-.869.732-1.809.832-.242.12c-1.665.918-2.442 2.476-3.129 3.85 0 0-1.48 3.026-1.771 6.398a1.292 1.292 0 0 0-.004.109c0 .998.864 1.81 1.926 1.81.078 0 .155-.006.231-.019a4.476 4.476 0 0 0 1.414-.47l5.547 1.531.042.009.007.001a.629.629 0 0 0 .134.016.65.65 0 0 0 .138-.016l.044-.009 5.547-1.531c.416.217.878.388 1.414.47.076.013.154.019.231.019 1.062 0 1.926-.812 1.926-1.81 0-.037-.003-.074-.003-.109 0-3.062-1.771-6.398-1.771-6.398-.688-1.374-1.465-2.931-3.13-3.85-.031-.017-.19-.095-.242-.12l-1.808-.832-.87-.733-1.431 1.179m-.727 12.162l-3.617-.998a1.525 1.525 0 0 0 .027-1.854 1.516 1.516 0 0 0-.803-.553v-5.033l4.42 1.236-.027 7.202zm5.756-3.404a1.521 1.521 0 0 0-.775 2.407l-3.618.998v-7.25l4.393-1.219v5.064zm0 0"/><path d="M11.844 10.38c1.832 0 4.288-2.288 4.33-6.124C16.2 1.594 14.933 0 11.844 0 8.756 0 7.488 1.594 7.516 4.256c.041 3.836 2.185 6.124 4.328 6.124z"/></symbol><symbol id="icon-interlibrary" viewBox="0 0 24 24"><path d="M20.5 4H20V.5a.5.5 0 0 0-.5-.5h-14A2.503 2.503 0 0 0 3 2.5v19C3 22.879 4.121 24 5.5 24h15a.5.5 0 0 0 .5-.5v-19a.5.5 0 0 0-.5-.5zM19 4h-1V2.5a.5.5 0 0 0-.5-.5h-12a.5.5 0 0 0 0 1H17v1H5.5C4.673 4 4 3.327 4 2.5S4.673 1 5.5 1H19v3z"/><path fill="#FFF" d="M19.516 17.603a.745.745 0 0 0-.617-.341h-4.892l1.724-1.66c.398-.398.385-1.059-.029-1.473-.4-.4-1.088-.414-1.472-.031l-4.06 4.02a.2.2 0 0 0-.001.283l3.992 4.032a.973.973 0 0 0 .694.282 1.103 1.103 0 0 0 1.091-1.092.973.973 0 0 0-.283-.693L14 19.266h4.91a.723.723 0 0 0 .611-.34 1.21 1.21 0 0 0 .189-.664 1.185 1.185 0 0 0-.194-.659zM13.702 9.805l-4.06-4.019c-.384-.384-1.071-.37-1.472.03-.414.414-.428 1.075-.026 1.476l1.729 1.657H4.974c-.508 0-.812.509-.812 1 0 .247.067.483.189.664.147.22.365.341.611.341h4.91L8.21 12.617a.97.97 0 0 0-.283.694 1.101 1.101 0 0 0 1.09 1.091.979.979 0 0 0 .696-.283l3.991-4.031a.202.202 0 0 0-.002-.283z"/></symbol><symbol id="icon-news" viewBox="0 0 24 24"><path d="M17 0H.5a.5.5 0 0 0-.5.5v20C0 22.431 1.57 24 3.5 24h14.94c-.845-.861-1.44-2.172-1.44-3.5V0zM3 6.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-.5.5h-5a.5.5 0 0 1-.5-.5v-6zM14.5 19h-11a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1zm0-2h-11a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1zm0-2h-11a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1zm0-2h-4a.5.5 0 0 1 0-1h4a.5.5 0 0 1 0 1zm0-2h-4a.5.5 0 0 1 0-1h4a.5.5 0 0 1 0 1zm0-2h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 1 0 1zm0-5h-11a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1z"/><path d="M23.5 3H20V1.5a.5.5 0 0 0-.5-.5H18v19.5c0 1.701 1.285 3.5 2.5 3.5 1.93 0 3.5-1.569 3.5-3.5v-17a.5.5 0 0 0-.5-.5zM21 20.5a.5.5 0 0 1-1 0V6h1v14.5z"/></symbol><symbol id="icon-next" viewBox="0 0 24 24"><path d="M12 .004c-6.617 0-12 5.383-12 12s5.383 12 12 12 12-5.383 12-12-5.384-12-12-12zm6.689 13.066l-5.515 5.821a1.463 1.463 0 0 1-1.07.461 1.46 1.46 0 0 1-1.042-.433l-.295-.294a1.577 1.577 0 0 1-.061-2.141L12.928 14H5.5c-.827 0-1.5-.673-1.5-1.5v-.996c0-.827.673-1.5 1.5-1.5l7.394.002-2.281-2.486a1.56 1.56 0 0 1 .047-2.136l.296-.296c.569-.567 1.559-.557 2.115.021l5.61 5.824c.566.588.57 1.546.008 2.137z"/></symbol><symbol id="icon-offcampus" viewBox="0 0 24 24"><path d="M18.722 13.57l3.81-4.114c1.53-1.652.842-4.672-.772-6.167l-1.823-1.688C19.184.902 18.062.413 16.935.289c-1.328-.146-2.467.214-3.206 1.013L9.917 5.416a3.002 3.002 0 0 0 .163 4.239l.089.083a1 1 0 1 0 1.358-1.469l-.089-.082a1.002 1.002 0 0 1-.054-1.414l3.81-4.114c.294-.317.849-.457 1.521-.383.705.077 1.418.379 1.86.79L20.4 4.757c.864.8 1.351 2.599.663 3.341l-3.81 4.114a1.002 1.002 0 0 1-1.413.054l-.089-.083a1 1 0 0 0-1.359 1.468l.089.083a3.003 3.003 0 0 0 4.241-.164zM9.517 10.264a2.987 2.987 0 0 0-2.154-.798 2.986 2.986 0 0 0-2.086.96l-3.81 4.113C.728 15.337.456 16.5.702 17.814c.209 1.113.783 2.195 1.537 2.892l1.823 1.688c.901.836 2.256 1.347 3.542 1.347 1.017 0 1.99-.318 2.666-1.048l3.81-4.113a3.002 3.002 0 0 0-.162-4.239l-.09-.083a1 1 0 1 0-1.358 1.468l.089.083c.405.375.429 1.009.055 1.413l-3.81 4.113c-.687.742-2.518.395-3.383-.406l-1.823-1.688c-.442-.41-.799-1.098-.93-1.795-.125-.666-.028-1.229.266-1.546l3.811-4.114a.996.996 0 0 1 1.413-.052l.089.083a1 1 0 1 0 1.358-1.469l-.088-.084z"/><path d="M7.583 16.767a.997.997 0 0 0 1.413-.054l7.475-8.07a1 1 0 0 0-1.468-1.359l-7.475 8.07a1 1 0 0 0 .055 1.413z"/></symbol><symbol id="icon-openlate" viewBox="0 0 24 24"><path d="M13.545 22.979C9.568 21.054 7 16.747 7 12.006c0-4.739 2.568-9.045 6.545-10.97a.5.5 0 0 0-.16-.946C6.284-.752 0 4.837 0 12.006c0 7.166 6.268 12.748 13.384 11.92a.5.5 0 0 0 .161-.947zM22.51 18.006c-2.402-.049-3.517-1.16-3.51-3.497v-.001a.501.501 0 0 0-.498-.502H18.5a.5.5 0 0 0-.5.498c-.01 2.356-1.124 3.471-3.507 3.502a.498.498 0 0 0-.49.504.502.502 0 0 0 .502.496c2.396 0 3.473 1.081 3.495 3.505a.499.499 0 0 0 .489.495h.011a.5.5 0 0 0 .499-.475c.12-2.405 1.224-3.525 3.499-3.525h.001a.5.5 0 0 0 .011-1z"/><path d="M15.998 11.006a.5.5 0 0 0 .013-1C14.615 9.977 13.995 9.36 14 8.008a.501.501 0 0 0-.498-.502H13.5a.5.5 0 0 0-.5.498v.001c-.005 1.364-.624 1.981-2.007 2.001a.498.498 0 0 0-.491.504.502.502 0 0 0 .502.496c1.387 0 1.983.6 1.996 2.005a.499.499 0 0 0 .489.495h.011a.5.5 0 0 0 .499-.475c.07-1.4.682-2.025 1.999-2.025zM23.51 4.006C21.769 3.971 20.995 3.2 21 1.509v-.001a.501.501 0 0 0-.498-.502H20.5a.5.5 0 0 0-.5.498c-.006 1.707-.78 2.48-2.507 2.502a.497.497 0 0 0-.49.504.502.502 0 0 0 .503.496c1.71 0 2.48.772 2.495 2.505a.5.5 0 0 0 .489.495h.011A.5.5 0 0 0 21 7.531c.087-1.746.853-2.525 2.499-2.525h.001a.5.5 0 0 0 .01-1z"/></symbol><symbol id="icon-outdoor" viewBox="0 0 24 24"><path d="M11.5 4C7.364 4 4 7.364 4 11.5S7.364 19 11.5 19s7.5-3.364 7.5-7.5S15.636 4 11.5 4zM11.5 20a.5.5 0 0 0-.5.5v2a.5.5 0 0 0 1 0v-2a.5.5 0 0 0-.5-.5zM18.354 17.646a.5.5 0 0 0-.707.707l1.5 1.5a.502.502 0 0 0 .707.001.5.5 0 0 0 0-.707l-1.5-1.501zM22.5 11h-2a.5.5 0 0 0 0 1h2a.5.5 0 0 0 0-1zM18 5.5a.5.5 0 0 0 .354-.147l1.5-1.5a.5.5 0 0 0-.707-.707l-1.5 1.5A.5.5 0 0 0 18 5.5zM11.5 3a.5.5 0 0 0 .5-.5v-2a.5.5 0 0 0-1 0v2a.5.5 0 0 0 .5.5zM4.647 5.353a.495.495 0 0 0 .706 0 .5.5 0 0 0 0-.707l-1.5-1.5a.5.5 0 0 0-.707.707l1.501 1.5zM2.5 11h-2a.5.5 0 0 0 0 1h2a.5.5 0 0 0 0-1zM4.647 17.646l-1.5 1.5a.5.5 0 0 0 .706.708l1.5-1.5a.5.5 0 0 0-.706-.708z"/></symbol><symbol id="icon-people" viewBox="0 0 24 24"><path d="M0 12.5c0 1.083.336 1.73 1 1.932V19h4v-4.568c.663-.202.998-.849 1-1.932V9H0v3.5zM18 9v3.5c0 1.083.336 1.73 1 1.932V19h4v-4.568c.663-.202.999-.849 1-1.932V9h-6zM8 14.5c0 1.208.86 2.218 2 2.45V23h4v-6.05c1.14-.232 2-1.242 2-2.45V9H8v5.5z"/><circle cx="21" cy="6" r="2"/><circle cx="3" cy="6" r="2"/><circle cx="12" cy="5" r="3"/></symbol><symbol id="icon-policy" viewBox="0 0 24 24"><path d="M11.998-.178C5.285-.178-.178 5.286-.178 12c0 6.713 5.462 12.177 12.176 12.177 6.717 0 12.179-5.464 12.179-12.177 0-6.714-5.462-12.178-12.179-12.178zm0 23.053C5.993 22.875 1.123 18.006 1.123 12S5.993 1.125 11.998 1.125c6.008 0 10.877 4.869 10.877 10.875s-4.869 10.875-10.877 10.875z"/><path fill="#FFF" d="M23.295 12c0 6.236-5.06 11.292-11.297 11.292C5.761 23.292.704 18.236.704 12 .704 5.762 5.762.704 11.998.704 18.235.705 23.295 5.762 23.295 12z"/><path d="M20.733 17.044a4.651 4.651 0 0 1-.914-3.668 4.654 4.654 0 0 1 2.116-3.123 4.637 4.637 0 0 1-3.682-4.543c0-.48.075-.959.221-1.419a4.665 4.665 0 0 1-3.763.255 4.651 4.651 0 0 1-2.709-2.626 4.669 4.669 0 0 1-2.72 2.63 4.646 4.646 0 0 1-3.752-.258c.145.459.221.935.221 1.415 0 .803-.208 1.61-.625 2.339a4.651 4.651 0 0 1-3.058 2.208 4.672 4.672 0 0 1 2.127 3.182c.042.252.062.505.062.755 0 1.04-.356 2.041-.986 2.854a4.658 4.658 0 0 1 3.618 1.03l.038.032.037.032a4.662 4.662 0 0 1 1.591 3.344 4.677 4.677 0 0 1 3.456-1.541c1.334 0 2.574.58 3.442 1.538a4.66 4.66 0 0 1 1.659-3.398 4.649 4.649 0 0 1 3.621-1.038z"/><path fill="#FFF" d="M19.438 12a7.429 7.429 0 0 1-7.429 7.429A7.43 7.43 0 1 1 19.438 12z"/><path d="M3.869 13.974c0-.058-.011-.112-.014-.169-1.037 1.04-1.703 2.27-1.703 3.144 0 .145.025.274.062.396.979-.759 1.655-2.132 1.655-3.371zm-2.96-3.676c.048.884 1.225 2.046 2.816 2.783-.379-1.206-1.564-2.386-2.816-2.783zm1.557 7.446c.621.657 2.263.813 3.912.382-1.082-.694-2.72-.858-3.912-.382zm2.145-9.572c-1.738.153-3.271.871-3.619 1.697 1.315.048 2.843-.677 3.619-1.697zm.68-2.273c0-.827-.214-1.658-.613-2.294-.229.303-.349.763-.349 1.322 0 .767.222 1.696.63 2.586a4.21 4.21 0 0 0 .332-1.614zM23.013 9.87c-.347-.826-1.878-1.545-3.618-1.697.774 1.019 2.302 1.745 3.618 1.697zM8.82 4.282c-1.388-.961-2.977-1.365-3.781-.961.957.858 2.521 1.254 3.781.961zM6.917 19.246c0 1.464.427 2.752 1.082 3.192.053-.25.103-.501.103-.769 0-1.103-.445-2.279-1.144-3.041-.017.208-.041.416-.041.618zM18.966 3.321c-.807-.404-2.393 0-3.779.961 1.246.284 2.834-.116 3.779-.961zm-1.34 14.806c1.649.432 3.292.274 3.914-.383-1.191-.476-2.832-.312-3.914.383zm2.511-4.155c0 1.241.676 2.615 1.655 3.374.036-.122.061-.253.061-.396 0-.875-.666-2.105-1.702-3.145-.004.055-.014.109-.014.167zm.142-.891c1.59-.736 2.767-1.896 2.816-2.783-1.251.397-2.437 1.578-2.816 2.783zm-4.376 8.585c0 .271.05.521.103.772.654-.44 1.082-1.728 1.082-3.19 0-.202-.025-.412-.042-.619-.699.762-1.143 1.938-1.143 3.037zm-3.544-1.328c.995 1.427 2.335 2.364 3.216 2.257-.61-1.166-1.952-2.102-3.216-2.257zM9.512 4.032C10.638 3.447 11.6 2.068 11.78.759c-.859.21-1.817 1.59-2.268 3.273zm4.982 0c-.45-1.683-1.409-3.063-2.269-3.273.18 1.309 1.142 2.688 2.269 3.273zM8.429 22.595c.881.106 2.221-.83 3.215-2.256-1.264.158-2.604 1.092-3.215 2.256zM19.048 7.514c.405-.891.629-1.818.629-2.583 0-.56-.121-1.021-.35-1.323-.398.637-.612 1.467-.612 2.293 0 .576.128 1.125.333 1.613zM9.033 8.707A11.172 11.172 0 0 0 5.6 8.239v.002c.498.967 1.227 1.958 2.142 2.847l3.484.459-2.193-2.84zM7.614 11.386a11.206 11.206 0 0 0-2.942 1.853v.001c1.002.42 2.197.711 3.467.805l2.978-1.894-3.503-.765zM8.237 14.353c-.554 1.115-.909 2.263-1.062 3.314l.002.001a11.235 11.235 0 0 0 3.183-1.622l1.066-3.364-3.189 1.671zM16.387 11.064a11.104 11.104 0 0 0 2.089-2.709v-.001c-1.1-.052-2.341.087-3.583.444l-2.115 2.749 3.609-.483zM14.751 8.476a11.19 11.19 0 0 0-.141-3.425l-.001-.001c-.874.666-1.73 1.565-2.451 2.631l.15 3.472 2.443-2.677zM11.843 7.553c-.683-1.023-1.491-1.894-2.318-2.547h-.001c-.24 1.065-.319 2.297-.19 3.569l2.363 2.578.146-3.6zM19.315 13.369c-.812-.749-1.854-1.44-3.037-1.964l-3.392.747 3.08 1.953a11.218 11.218 0 0 0 3.349-.736zM13.678 16.147c.993.73 2.054 1.272 3.055 1.604v-.001c-.125-.972-.871-2.905-1.095-3.474l-3.059-1.594 1.099 3.465zM10.625 16.237a11.209 11.209 0 0 0 1.312 3.21h.001c.592-.921 1.09-2.057 1.402-3.304l-1.338-3.25-1.377 3.344z"/><path d="M3.864 12c0 4.491 3.653 8.144 8.145 8.144 4.49 0 8.143-3.653 8.143-8.144s-3.653-8.145-8.143-8.145C7.517 3.856 3.864 7.51 3.864 12zm.342 0c0-4.303 3.5-7.803 7.803-7.803 4.301 0 7.802 3.5 7.802 7.803 0 4.302-3.501 7.803-7.802 7.803-4.304.001-7.803-3.5-7.803-7.803z"/><path d="M13.683 11.997a1.68 1.68 0 1 1-3.358 0 1.68 1.68 0 0 1 3.358 0z"/><path fill="#FFF" d="M10.242 11.999c0 .973.791 1.764 1.763 1.764.974 0 1.765-.791 1.765-1.764a1.765 1.765 0 0 0-3.528 0zm.17 0a1.595 1.595 0 1 1 3.19.002 1.595 1.595 0 0 1-3.19-.002z"/></symbol><symbol id="icon-previous" viewBox="0 0 24 24"><path d="M12 .004c-6.617 0-12 5.383-12 12s5.383 12 12 12 12-5.383 12-12-5.384-12-12-12zM19 12.5c0 .827-.673 1.5-1.5 1.5h-7.382l2.222 2.486a1.574 1.574 0 0 1-.061 2.139l-.296.296a1.468 1.468 0 0 1-1.042.432c-.408 0-.788-.164-1.069-.46L4.356 13.07a1.563 1.563 0 0 1 .008-2.137l5.611-5.824c.555-.579 1.546-.589 2.115-.021l.296.296a1.56 1.56 0 0 1 .047 2.136l-2.281 2.486 7.348-.002c.827 0 1.5.673 1.5 1.5v.996z"/></symbol><symbol id="icon-printer" viewBox="0 0 24 24"><circle cx="3.5" cy="10.5" r=".5"/><path d="M21.5 7h-19A2.503 2.503 0 0 0 0 9.5v6C0 16.878 1.121 18 2.5 18H5v4.5a.5.5 0 0 0 .5.5h13a.5.5 0 0 0 .5-.5V18h2.5c1.378 0 2.5-1.122 2.5-2.5v-6C24 8.122 22.878 7 21.5 7zm-18 5c-.827 0-1.5-.673-1.5-1.5S2.673 9 3.5 9c.826 0 1.5.673 1.5 1.5S4.326 12 3.5 12zM18 22H6v-7h12v7zM5.5 6h13a.5.5 0 0 0 .5-.5v-1a.504.504 0 0 0-.146-.354l-3-3A.504.504 0 0 0 15.5 1h-10a.5.5 0 0 0-.5.5v4a.5.5 0 0 0 .5.5zm10-4.5l3 3h-3v-3z"/><path d="M7.5 17h9a.5.5 0 0 0 0-1h-9a.5.5 0 0 0 0 1zM7.5 19h9a.5.5 0 0 0 0-1h-9a.5.5 0 0 0 0 1zM7.5 21h9a.5.5 0 0 0 0-1h-9a.5.5 0 0 0 0 1z"/></symbol><symbol id="icon-projects" viewBox="0 0 24 24"><path d="M11.5 5A6.508 6.508 0 0 0 5 11.5a6.494 6.494 0 0 0 4.5 6.18v.82a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-.82A6.497 6.497 0 0 0 18 11.5C18 7.916 15.084 5 11.5 5zM12 22h-1a.5.5 0 0 0 0 1h1a.5.5 0 0 0 0-1zM13 20h-3a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1zM11.5 4a.5.5 0 0 0 .5-.5v-2a.5.5 0 0 0-1 0v2a.5.5 0 0 0 .5.5zM21.5 11h-2a.5.5 0 0 0 0 1h2a.5.5 0 0 0 0-1zM3.5 11h-2a.5.5 0 0 0 0 1h2a.5.5 0 0 0 0-1zM5.488 6.199a.502.502 0 0 0 .707 0 .5.5 0 0 0 0-.707L4.074 3.369a.5.5 0 0 0-.707.707l2.121 2.123zM17.155 6.345a.502.502 0 0 0 .354-.146l2.122-2.122a.5.5 0 0 0-.707-.707l-2.122 2.122a.5.5 0 0 0 .353.853z"/></symbol><symbol id="icon-quiet" viewBox="0 0 24 24"><path d="M2 15h3.172L13 7.173V1.5a.498.498 0 0 0-.309-.462.499.499 0 0 0-.545.108L5.293 8H2c-1.103 0-2 .897-2 2v3c0 1.104.897 2 2 2zM12.146 21.854A.5.5 0 0 0 13 21.5v-8.672l-4.939 4.94 4.085 4.086zM16.322 9.506c.391.536.678 1.196.678 1.994 0 1.482-.976 2.501-1.793 3.096a.498.498 0 1 0 .586.809C17.217 14.372 18 12.985 18 11.5c0-.967-.339-1.892-.965-2.706l-.713.712zM22.207.793a1 1 0 0 0-1.414 0l-20 20c-.435.435-.35 1.136.016 1.427.38.364 1.025.361 1.398-.013l20-20a1.005 1.005 0 0 0 0-1.414z"/></symbol><symbol id="icon-reserves" viewBox="0 0 24 24"><path d="M21.5 0h-19A2.503 2.503 0 0 0 0 2.5V24h3.36l1-3h15.267l1.031 3H24V2.5C24 1.122 22.878 0 21.5 0zM21 18h-1v-4.5a.5.5 0 0 0-.5-.5H17v5h-1v-5h-3v5h-1v-5H9.5a.5.5 0 0 0-.5.5V18H3v-6h18v6zm0-9h-2.737l.1-.037a.499.499 0 0 0 .294-.643l-1.646-4.428a.498.498 0 0 0-.643-.295l-1.799.669a.5.5 0 0 1 .083.134l1.646 4.428a.49.49 0 0 1 .027.172H14V4.5a.5.5 0 0 0-.5-.5H11v5h-1V4H7v5H6V4H4.5a.5.5 0 0 0-.5.5V9H3V3h18v6z"/></symbol><symbol id="icon-scanner" viewBox="0 0 24 24"><path d="M23.839 19l-3.811-9.526 1.925-6.737a.494.494 0 0 0 .067-.237.505.505 0 0 0-.025-.156A2.503 2.503 0 0 0 19.5 0h-15a2.497 2.497 0 0 0-2.49 2.406l-.001.008C2.008 2.443 2 2.471 2 2.5s.012.054.017.082c.003.019-.003.037.002.056l1.953 6.836L.161 19h23.678zm-3.933-1.208A.499.499 0 0 1 19.5 18h-15a.499.499 0 0 1-.474-.658l2-6A.5.5 0 0 1 6.5 11h11a.5.5 0 0 1 .474.342l2 6a.498.498 0 0 1-.068.45zM3.163 3h17.674l-1.714 6H4.877L3.163 3zM.051 20c.246 2.473 2.271 4 5.449 4h13c3.178 0 5.203-1.527 5.449-4H.051zM16.5 22a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1zm3 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1z"/></symbol><symbol id="icon-search" viewBox="0 0 24 24"><path d="M9 18a8.955 8.955 0 0 0 5.633-1.992l7.658 7.697a1 1 0 1 0 1.418-1.411l-7.668-7.707A8.939 8.939 0 0 0 18 9c0-4.963-4.037-9-9-9S0 4.037 0 9c0 4.962 4.037 9 9 9zM9 2c3.859 0 7 3.14 7 7 0 3.859-3.141 7-7 7-3.86 0-7-3.141-7-7 0-3.86 3.14-7 7-7z"/></symbol><symbol id="icon-study" viewBox="0 0 24 24"><path d="M22.5 23H20V12.5c0-5.069-3.995-9.212-9-9.475V3c0-1.654-1.346-3-3-3S5 1.346 5 3v2.177A6.976 6.976 0 0 0 1 11.5v2a.5.5 0 0 0 .5.5h13a.5.5 0 0 0 .5-.5v-2a6.98 6.98 0 0 0-4-6.323V4.025c4.453.26 8 3.957 8 8.475V23h-4.5a.5.5 0 1 0 0 1h8a.5.5 0 0 0 0-1z"/></symbol><symbol id="icon-supporting" viewBox="0 0 24 24"><path d="M3.5 14.008h-3a.5.5 0 0 0-.5.5v8c0 .275.224.5.5.492h3a.49.49 0 0 0 .5-.492v-8a.5.5 0 0 0-.5-.5zM23.854 18.153c-1.175-1.174-2.187-1.499-3.512-1.121l-3.008.998c.026.157.041.316.041.477 0 .64-.208 1.241-.585 1.694-.438.526-1.058.806-1.79.806H9.5a.5.5 0 0 1-.5-.5c0-.277.224-.5.5-.508H15c.432.008.775-.143 1.021-.438.225-.27.354-.653.354-1.054 0-.559-.29-1.5-1.375-1.5h-3a.5.5 0 0 1-.354-.147c-.558-.558-2.077-1.853-4.146-1.853h-2a.5.5 0 0 0-.5.5v5.5c0 .215.138.405.342.473 1.584.528 2.831.981 3.833 1.346 2.004.727 3.13 1.122 4.141 1.122 1.212 0 2.257-.567 4.453-1.808 1.368-.772 3.241-1.83 5.955-3.186a.505.505 0 0 0 .27-.368.504.504 0 0 0-.14-.433zM8.655 11.258c.79 0 1.476-.383 2.049-1.133 1.355 2.493 1.812 4.485 1.818 4.519.091.42.444.765.977.787.414 0 .79-.261.936-.649.032-.084.477-1.228 1.319-2.446.562.637 1.188.801 1.687.801.794 0 1.662-.436 2.381-1.194 1.201-1.265 1.891-4.684.955-6.72a.496.496 0 0 0-.756-.191c-.876.661-1.686.87-2.543 1.092-.738.191-1.503.389-2.257.892-.869.579-1.368 1.378-1.37 2.187-.001.402.123.945.622 1.506-.288.374-.544.748-.764 1.104a23.286 23.286 0 0 0-1.521-3.163c.741-.509 1.199-1.112 1.359-1.805.231-.997-.155-2.096-1.148-3.263-.928-1.095-2.17-1.469-3.485-1.864-1.151-.347-2.341-.704-3.39-1.591a.489.489 0 0 0-.418-.109.492.492 0 0 0-.344.255c-1.378 2.606-.73 7.352.778 9.129.718.846 1.841 1.856 3.115 1.856zM6.884 3.721c.192-.193.462-.221.771.057a21.304 21.304 0 0 1 4.106 5.136l.005-.003c.961 1.667 1.404 2.862 1.843 4.066 1.027-1.801 2.294-3.559 4.166-4.494a.506.506 0 0 1 .646.192c.198.34.028.483-.198.702-2.192 1.096-3.824 3.963-4.255 5.228-.16.422-.771.448-.935-.011-.354-1-.549-2.304-2.017-4.933l.003-.004c-.934-1.675-2.263-3.547-4.118-5.216a.513.513 0 0 1-.017-.72z"/></symbol><symbol id="icon-table" viewBox="0 0 24 24"><g transform="matrix(1.33333 0 0 -1.33333 0 32)"><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><g clip-path="url(#b)"><path fill="#010101" d="M14.063 22.969l-10.312-.094c-.276 0-3.594-4.629-3.594-4.906v-11.5a.5.5 0 0 1 1 0v10.5h12.999l-.093 6z"/></g></g><path fill="#010101" d="M4.251 6.666v12.207a.667.667 0 0 0 1.334 0V4.874M18.501 6.666v12.207a.667.667 0 0 0 1.334 0V4.874"/><path fill="#010101" d="M18.501 9.334h4.165v14a.667.667 0 0 0 1.334 0V8c0-.369-4.882-6.541-5.25-6.541l-.249 1.208v6.667z"/></symbol><symbol id="icon-tours" viewBox="0 0 24 24"><path d="M23.512 2a.5.5 0 0 0-.5.5v.63l-22 6.695V9.5a.5.5 0 0 0-1 0v5a.5.5 0 0 0 1 0v-.325l4 1.217v2.219c0 2.206 1.794 4 4 4A4 4 0 0 0 13 17.823l10.012 3.046v.63a.5.5 0 0 0 1 0v-19a.5.5 0 0 0-.5-.499zm-11.5 15.611c0 1.654-1.346 3-3 3s-3-1.346-3.012-3v-1.914l6.012 1.826v.088z"/></symbol><symbol id="icon-twitter-circle" viewBox="0 0 24 24"><path d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm5.262 9.385c.006.113.008.226.008.34 0 3.478-2.647 7.489-7.488 7.489a7.452 7.452 0 0 1-4.035-1.184 5.291 5.291 0 0 0 3.896-1.089 2.636 2.636 0 0 1-2.458-1.829c.396.075.803.061 1.188-.046a2.631 2.631 0 0 1-2.111-2.579v-.035c.355.197.762.315 1.192.33a2.632 2.632 0 0 1-.815-3.514 7.463 7.463 0 0 0 5.425 2.75 2.632 2.632 0 0 1 4.486-2.399c.6-.119 1.95-.266 1.95-.266-.353.529-.724 1.66-1.238 2.032z"/></symbol><symbol id="icon-working" viewBox="0 0 24 24"><path d="M23.854 23.146l-5.597-5.594A10.448 10.448 0 0 0 21 10.5C21 4.71 16.29 0 10.5 0S0 4.71 0 10.5 4.71 21 10.5 21a10.44 10.44 0 0 0 7.05-2.742l5.597 5.595a.502.502 0 0 0 .707.001.502.502 0 0 0 0-.708zM1 10.5C1 5.262 5.262 1 10.5 1S20 5.262 20 10.5 15.738 20 10.5 20 1 15.738 1 10.5z"/><path d="M12.551 7.755h-1.073a.5.5 0 0 0-.5.5v4.491a.5.5 0 0 0 .5.5h1.073c1.044 0 1.573-.546 1.573-1.623 0-.48-.105-.854-.314-1.123.209-.267.314-.642.314-1.121 0-1.078-.529-1.624-1.573-1.624zm0 4.491h-.573V11h.573c.506 0 .573.125.573.623s-.067.623-.573.623zm0-2.246h-.573V8.755h.573c.506 0 .573.125.573.624 0 .496-.067.621-.573.621zM5.425 7.73a.5.5 0 0 0-.5.5l.001 3.532c0 .002 0 .231-.129.367-.174.186-.714.185-.89.002-.116-.123-.133-.332-.13-.403a.5.5 0 0 0-.461-.531.518.518 0 0 0-.537.461c-.005.069-.038.685.392 1.149.195.21.559.461 1.181.461.616 0 .978-.247 1.173-.453.425-.45.403-1.045.4-1.083V8.23a.5.5 0 0 0-.5-.5zM8.451 7.706c-1.77 0-1.77 2.03-1.77 2.794 0 .764 0 2.795 1.77 2.795 1.769 0 1.769-2.031 1.769-2.795 0-.764 0-2.794-1.769-2.794zm0 4.589c-.39 0-.77-.139-.77-1.795 0-1.655.38-1.794.77-1.794.389 0 .769.139.769 1.794 0 1.656-.38 1.795-.769 1.795zM18.224 11.648c0-.572-.242-1.316-1.395-1.618l-.104-.028c-.473-.123-.648-.298-.648-.647 0-.357.258-.648.575-.648.302 0 .554.265.573.604a.5.5 0 1 0 .998-.058c-.051-.867-.741-1.546-1.571-1.546-.868 0-1.575.739-1.575 1.648 0 .571.242 1.315 1.396 1.615l.126-.484-.022.512c.472.124.647.301.647.65 0 .357-.258.647-.575.647-.302 0-.554-.266-.573-.604a.51.51 0 0 0-.528-.47.5.5 0 0 0-.47.528c.051.867.741 1.546 1.571 1.546.868 0 1.575-.739 1.575-1.647z"/></symbol></svg>  </div>
+</body>
+</html>

--- a/spec/services/library_website_search_service_spec.rb
+++ b/spec/services/library_website_search_service_spec.rb
@@ -1,36 +1,86 @@
 require 'rails_helper'
 
 RSpec.describe LibraryWebsiteSearchService do
-  subject(:service) { described_class.new }
-  let(:query) { LibraryWebsiteSearchService::Request.new('my query') }
-  let(:response) { service.search(query) }
-  before do
-    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
-                                                               success?: true,
-                                                               body: body))
+  context 'request/response' do
+    subject(:service) { described_class.new }
+    let(:query) { LibraryWebsiteSearchService::Request.new('my query') }
+    let(:response) { service.search(query) }
+    before do
+      allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                                 success?: true,
+                                                                 body: body))
+    end
+
+    context 'example 1' do
+      let(:body) { File.read(Rails.root.join('spec', 'fixtures', 'library.stanford.edu', '1.html')) }
+
+      it '#results' do
+        results = response.results
+        expect(results.length).to eq 3
+        expect(results.first.to_h).to include(title: 'Darren Hardy PhD',
+                                              link: '/people/drh',
+                                              breadcrumbs: ' » ',
+                                              description: /Darren Hardy develops/)
+      end
+      it '#facets' do
+        facets = response.facets
+        expect(facets.length).to eq 1
+        expect(facets.first).to include('name' => 'document_type_facet')
+        expect(facets.first['items'].length).to eq 2
+        expect(facets.first['items'][0]).to include('value' => 'type:blog', 'label' => 'Blog', 'hits' => 4)
+        expect(facets.first['items'][1]).to include('value' => 'type:person', 'label' => 'Person', 'hits' => 2)
+      end
+      it '#total' do
+        expect(response.total).to be_nil
+      end
+    end
+
+    context 'example 2' do
+      let(:body) { File.read(Rails.root.join('spec', 'fixtures', 'library.stanford.edu', '2.html')) }
+
+      it '#results' do
+        results = response.results
+        expect(results.length).to eq 3
+        expect(results.first.to_h).to include(title: 'Books',
+                                              link: '/department/metadata-department/services/new-record-or-record-change-requests/books',
+                                              breadcrumbs: ' » ',
+                                              description: /Document for new record and record change/)
+      end
+      it '#facets' do
+        facets = response.facets
+        expect(facets.length).to eq 1
+        expect(facets.first).to include('name' => 'document_type_facet')
+        expect(facets.first['items'].length).to eq 16
+        expect(facets.first['items'][0]).to include('value' => 'type:site_microsite', 'label' => 'Group page', 'hits' => 946)
+        expect(facets.first['items'][1]).to include('value' => 'type:library_page', 'label' => 'Library microsite', 'hits' => 566)
+      end
+      it '#total' do
+        expect(response.total).to be_nil
+      end
+    end
   end
 
-  context 'example 1' do
-    let(:body) { File.read(Rails.root.join('spec', 'fixtures', 'library.stanford.edu', '1.html')) }
+  context 'facets' do
+    let(:facet_hash) { { 'label' => 'Facet Label', 'value' => 'type:facet value', 'hits' => 20 } }
 
-    it '#results' do
-      results = response.results
-      expect(results.length).to eq 3
-      expect(results.first.to_h).to include(title: 'Darren Hardy PhD',
-                                            link: '/people/drh',
-                                            breadcrumbs: ' » ',
-                                            description: /Darren Hardy develops/)
+    let(:facet_item) do
+      LibraryWebsiteSearchService::HighlightedFacetItem.new(facet_hash, 'facet_name', 'http://example.com/?q=%{q}')
     end
-    it '#facets' do
-      facets = response.facets
-      expect(facets.length).to eq 1
-      expect(facets.first).to include('name' => 'document_type_facet')
-      expect(facets.first['items'].length).to eq 2
-      expect(facets.first['items'][0]).to include('value' => 'Blog', 'label' => 'Blog', 'hits' => 4)
-      expect(facets.first['items'][1]).to include('value' => 'Person', 'label' => 'Person', 'hits' => 2)
+
+    it 'has attributes matched to hash accessors' do
+      expect(facet_item.label).to eq 'Facet Label'
+      expect(facet_item.value).to eq 'type:facet value'
+      expect(facet_item.hits).to be 20
     end
-    it '#total' do
-      expect(response.total).to be_nil
+
+    describe 'query_url' do
+      it 'interpolates the q attribute' do
+        expect(facet_item.query_url('abc')).to include 'example.com/?q=abc'
+      end
+
+      it 'appends the transformed facet value' do
+        expect(facet_item.query_url('abc')).to include '&f[0]=type%3Afacet+value'
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes #67. It updates the abstract class so that the HighlightedFacetItem can be overriden by the service subclasses.

- [x] Basic `type:` facets
- [x] Other types of search terms (requires extracting the hrefs from the HTML)
- [x] Cleanup override mechanism

The library website facets now have the search terms parsed out of the Drupal URL while keeping their label (e.g., "News (archived)" is actually the search term "type:news").

![screen shot 2017-09-18 at 10 21 17 am](https://user-images.githubusercontent.com/1861171/30555011-24c43178-9c5b-11e7-978b-572ce703bb67.png)
