### PR TITLE
Stylin': base font size and vertical spacing

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -30,6 +30,7 @@ h1 {
 h2 {
   color: $sul-h2-font-color ;
   font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
+  font-weight: 400;
   letter-spacing: 0;
   line-height: 1.2em;
 }

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -11,8 +11,9 @@ a {
 }
 
 body {
+  color: $sul-text-color;
   font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
-  // color: $sul-text-color;
+  font-size: 15px;
 }
 
 a:hover, a:focus, a:active  {

--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -1,6 +1,5 @@
 .result-title {
   font-size: 18px;
-  padding-bottom: 10px;
   padding-top: 10px;
 }
 
@@ -16,4 +15,10 @@
   font-size: 14px;
   padding-bottom: 10px;
   padding-top: 10px;
+}
+
+.result {
+  p {
+    margin-bottom: 0.5rem;
+  }
 }

--- a/app/views/quick_search/search/_see_all.html.erb
+++ b/app/views/quick_search/search/_see_all.html.erb
@@ -1,4 +1,4 @@
-<%= link_to (module_link), :class => "see-all-results" do %>
+<%= link_to (module_link), :class => "see-all-results btn btn-sul" do %>
     <% short_display_name = I18n.t("#{service_name}_search.short_display_name") %>
     <i class='fa fa-angle-right'></i>
     <% if total == '1' %>


### PR DESCRIPTION
Addresses part of #68 , includes pre-requisite commits from #74 

- Changes base font size from Chrome default 16px to Searchworks-y 15px
- Reduces vertical spacing between result elements
- adds button styling to "See all results" links
- increases `font-weight` for `<h2>` to 400

## Before
<img width="1146" alt="result_before" src="https://user-images.githubusercontent.com/5402927/30618370-e93737e6-9d4e-11e7-868f-1f416de25f01.png">

## After
<img width="1138" alt="result_after" src="https://user-images.githubusercontent.com/5402927/30618371-e937f3c0-9d4e-11e7-8a2c-c177a15742b0.png">
