### PR TITLE
Mount quicksearch engine under "/all"

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
-  mount QuickSearch::Engine => "/"
+  root to: 'quick_search/search#index'
+  mount QuickSearch::Engine => '/all'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
This is so our reverse proxy on library.stanford.edu works appropriately.