### PR TITLE
Add differentiating styles to Yewno module

### DIFF
--- a/app/assets/javascripts/yewno.js
+++ b/app/assets/javascripts/yewno.js
@@ -6,4 +6,9 @@ $(window).ready(function() {
       urlSearchParam: "q"
     })
   });
-}); 
+
+  var query = $('#params-q').attr('value');
+  $('.yn-figcaption a').addClass('btn-yewno');
+  $('.yn-figcaption a').addClass('btn');
+  $('.yn-figcaption a').text('Explore "' + query + '" in Yewno Discover');
+});

--- a/app/assets/stylesheets/modules/buttons.scss
+++ b/app/assets/stylesheets/modules/buttons.scss
@@ -13,3 +13,7 @@
 .btn-danger {
   @include button-variant($boston-university-red, $boston-university-red)
 }
+
+.btn-yewno {
+  @include button-variant($black, $black);
+}

--- a/app/assets/stylesheets/yewno.scss
+++ b/app/assets/stylesheets/yewno.scss
@@ -5,9 +5,11 @@
   height: 400px;
 }
 
-.yn-figcaption a {
-  @include button-variant($black, $black);
-  display: block;
-  font-size: 13px;
+.yn-figcaption {
   text-align: center;
+}
+
+.btn-yewno {
+  font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
+  display: inline-block;
 }

--- a/app/assets/stylesheets/yewno.scss
+++ b/app/assets/stylesheets/yewno.scss
@@ -1,3 +1,13 @@
+#yewno {
+  border-color: $black;
+}
 .yewno #yewno-results {
   height: 400px;
+}
+
+.yn-figcaption a {
+  @include button-variant($black, $black);
+  display: block;
+  font-size: 13px;
+  text-align: center;
 }

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -36,6 +36,7 @@
     <div class="col-md-6 yewno module">
       <div id="yewno" class="module-contents">
         <h2 class="result-set-heading">Yewno</h2>
+        <h3 class="result-set-subheading">Explore relationships among concepts</h3>
         <div id="yewno-results"></div>
       </div>
     </div>


### PR DESCRIPTION
Closes #83 

This PR adds some styling to differentiate the Yewno module from Stanford results:
- black border-top for the module
- black background for the link out to Yewno
- subtitle for the Yewno module

Unfortunately, I don't have much leeway with the "Explore other concepts" link. It gets positioned absolutely by Yewno's external stylesheet. I have two options for fixes below:

## Before
![yewno_before](https://user-images.githubusercontent.com/5402927/30661284-5d3026e0-9df8-11e7-851b-bd45417dd50e.png)

## After (option 1)
![yewno_after](https://user-images.githubusercontent.com/5402927/30661285-5d44dd56-9df8-11e7-8c1a-c828fa1e61bb.png)

## After (option 2) 
![yewno_after_button](https://user-images.githubusercontent.com/5402927/30662431-e98f532e-9dfb-11e7-9a57-542ebda5fcd7.png)
