### PR TITLE
add database search results to Catalog bento

### DIFF
--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -22,3 +22,8 @@
     margin-bottom: 0.5rem;
   }
 }
+
+.result-database-hits {
+  text-align: center;
+  padding: 10px;
+}

--- a/app/searchers/quick_search/catalog_searcher.rb
+++ b/app/searchers/quick_search/catalog_searcher.rb
@@ -9,5 +9,9 @@ module QuickSearch
     def loaded_link
       Settings.CATALOG_QUERY_URL.to_s % { q: URI.escape(q.to_s) }
     end
+
+    def database_results
+      @response.database_results(q)
+    end
   end
 end

--- a/app/services/catalog_search_service.rb
+++ b/app/services/catalog_search_service.rb
@@ -30,6 +30,18 @@ class CatalogSearchService < AbstractSearchService
       json['response']['facets']
     end
 
+    def database_results(q)
+      hits = 0
+      if highlighted_facet['items'].present?
+        database = highlighted_facet['items'].find { |i| i['value'] == 'Database' }
+        hits = database['hits'].to_i if database.present?
+      end
+      {
+        hits: hits,
+        link: QUERY_URL.to_s % { q: q } + '&f[format_main_ssim][]=Database'
+      }
+    end
+
     private
 
     def json

--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -23,6 +23,16 @@
         <ol>
             <%= render partial: '/quick_search/search/result', collection: searcher.results %>
         </ol>
+
+        <% if searcher.respond_to?(:database_results) %>
+          <% dbresults = searcher.database_results %>
+          <% if dbresults[:hits].positive? %>
+            <h6 class="result-database-hits">
+              Your search also found <a href="<%= dbresults[:link] -%>"><%= number_with_delimiter(dbresults[:hits]) -%> topic-specific databases</a>.
+            </h6>
+          <% end %>
+        <% end %>
+
         <p class="see-all-results">
             <% unless defined? searcher.loaded_link_mobile %>
                 <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link} %>

--- a/spec/searchers/quick_search/catalog_searcher_spec.rb
+++ b/spec/searchers/quick_search/catalog_searcher_spec.rb
@@ -16,4 +16,5 @@ RSpec.describe QuickSearch::CatalogSearcher do
     searcher.search # loads response
     expect(searcher.results).to be_an(Array)
   end
+  it { expect(searcher.respond_to?(:database_results)).to be_truthy }
 end

--- a/spec/services/catalog_search_service_spec.rb
+++ b/spec/services/catalog_search_service_spec.rb
@@ -13,4 +13,5 @@ RSpec.describe CatalogSearchService do
 
   it { expect(service).to be_an AbstractSearchService }
   it { expect(service.search(query)).to be_an CatalogSearchService::Response }
+  pending 'mimic database results facet'
 end


### PR DESCRIPTION
This PR fixes #89. It uses the format facet to locate how many 'Database' hits there are and then displays that and a link to search for them to the bottom of the Catalog results. It only applies to Catalog results. When there's no database hits, then the entire message is omitted.

Note that we don't have any specs that mimic catalog results as yet AFAICT, so the tests are marked pending.

![screen shot 2017-09-20 at 12 57 48 pm](https://user-images.githubusercontent.com/1861171/30665210-18f08c74-9e05-11e7-959d-9a086f6e95f1.png)
