### PR TITLE
Redirect 'about' page to home page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   root to: 'quick_search/search#index'
   mount QuickSearch::Engine => '/all'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get '/about', to: redirect('/all')
 end


### PR DESCRIPTION
Closes #88 

This PR overrides the 'About' page baked into the `quick_search` gem by redirecting `/all/about` to `/all`. 