### PR TITLE
Move search results button

### DIFF
--- a/app/assets/stylesheets/modules/results.scss
+++ b/app/assets/stylesheets/modules/results.scss
@@ -19,6 +19,25 @@
 
 .result {
   p {
-    margin-bottom: 0.5rem;
+    margin-bottom: .5rem;
+  }
+}
+
+.see-all-results {
+  text-align: right;
+
+  .btn {
+    white-space: normal;
+  }
+}
+
+@include media-breakpoint-down(md) {
+  .result-set-heading,
+  .result-set-subheading {
+    text-align: center;
+  }
+
+  .see-all-results .btn {
+    display: block;
   }
 }

--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -1,6 +1,7 @@
 <div id="<%= service_name.dasherize %>" class="module-contents" >
+    <% total = searcher.total.present? ? number_with_delimiter(searcher.total) : nil %>
     <% if searcher.is_a? StandardError %>
-        <%= render partial: 'module_heading', locals: { service_name: service_name } %>
+        <%= render partial: 'module_heading', locals: { service_name: service_name, total: total } %>
         <% if params[:page].blank? %>
             <% page = 1 %>
         <% else %>
@@ -8,33 +9,19 @@
         <% end %>
         <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'without_paging' } %>
     <% elsif searcher.results.blank? %>
-        <%= render partial: 'module_heading', locals: { service_name: service_name } %>
+        <%= render partial: 'module_heading', locals: { service_name: service_name, total: total } %>
         <%= render partial: '/quick_search/search/no_results', locals: {module_display_name: module_display_name, service_name: service_name} %>
     <% else %>
-        <% total = searcher.total.present? ? number_with_delimiter(searcher.total) : nil %>
         <% unless defined? searcher.loaded_link_mobile %>
-          <%= render partial: 'module_heading', locals: { service_name: service_name } %>
+          <%= render partial: 'module_heading', locals: { service_name: service_name, total: total, searcher: searcher } %>
         <% else %>
-          <%= render partial: 'module_heading', locals: { service_name: service_name } %>
+          <%= render partial: 'module_heading', locals: { service_name: service_name, total: total, searcher: searcher } %>
         <% end %>
-
         <%= render partial: '/quick_search/search/highlighted_facet', locals: { searcher: searcher } %>
 
         <ol>
             <%= render partial: '/quick_search/search/result', collection: searcher.results %>
         </ol>
-        <p class="see-all-results">
-            <% unless defined? searcher.loaded_link_mobile %>
-                <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link} %>
-            <% else %>
-                <span class="show-for-medium-up">
-                <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link} %>
-                </span>
-                <span class="show-for-small-only">
-                <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link_mobile} %>
-                </span>
-            <% end %>
-        </p>
         <% if searcher.total.present? %>
           <script type='text/javascript'>
             var searcherLink = $('.searcher-anchors a[href="#<%= service_name %>"]');

--- a/app/views/quick_search/search/_module_heading.html.erb
+++ b/app/views/quick_search/search/_module_heading.html.erb
@@ -1,6 +1,22 @@
-<h2 class='result-set-heading'>
-  <%= I18n.t("#{service_name}_search.display_name") %>
-</h2>
+<div class="row">
+  <div class="col-md-5">
+    <h2 class='result-set-heading'>
+      <%= I18n.t("#{service_name}_search.display_name") %>
+    </h2>
+  </div>
+  <div class="col-md-7 see-all-results">
+    <% unless defined? searcher.loaded_link_mobile %>
+      <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link} %>
+    <% else %>
+      <span class="show-for-medium-up">
+        <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link} %>
+      </span>
+      <span class="show-for-small-only">
+        <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link_mobile} %>
+      </span>
+    <% end %>
+  </div>
+</div>
 <h3 class='result-set-subheading'>
   <%= I18n.t("#{service_name}_search.sub_heading_html") %>
 </h3>

--- a/app/views/quick_search/search/_see_all.html.erb
+++ b/app/views/quick_search/search/_see_all.html.erb
@@ -2,12 +2,12 @@
     <% short_display_name = I18n.t("#{service_name}_search.short_display_name") %>
     <i class='fa fa-angle-right'></i>
     <% if total == '1' %>
-        <%= I18n.t("#{service_name}_search.see_all_message", :default => "See #{total} #{short_display_name} result") %>
+        <%= I18n.t("#{service_name}_search.see_all_message", :default => "See #{total} result") %>
     <% elsif total == '2' or total == '3' %>
-        <%= I18n.t("#{service_name}_search.see_all_message", :default => "See #{total} #{short_display_name} results") %>
+        <%= I18n.t("#{service_name}_search.see_all_message", :default => "See #{total} results") %>
     <% elsif total.nil? %>
-        <%= I18n.t("#{service_name}_search.see_all_message", :default => "See all #{short_display_name} results") %>
+        <%= I18n.t("#{service_name}_search.see_all_message", :default => "See all results") %>
     <% else %>
-        <%= I18n.t("#{service_name}_search.see_all_message", :default => "See all #{total} #{short_display_name} results") %>
+        <%= I18n.t("#{service_name}_search.see_all_message", :default => "See all #{total} results") %>
     <% end %>
 <% end %>

--- a/app/views/quick_search/search/_see_all.html.erb
+++ b/app/views/quick_search/search/_see_all.html.erb
@@ -1,4 +1,4 @@
-<%= link_to (module_link), :class => "see-all-results btn btn-sul" do %>
+<%= link_to (module_link), :class => "btn btn-sul" do %>
     <% short_display_name = I18n.t("#{service_name}_search.short_display_name") %>
     <i class='fa fa-angle-right'></i>
     <% if total == '1' %>

--- a/spec/features/searcher_anchors_spec.rb
+++ b/spec/features/searcher_anchors_spec.rb
@@ -27,7 +27,7 @@ describe 'Searcher Anchor Links', js: true do
     it 'updates the anchor link with the total count' do
       expect(page).to have_css('.see-all-results', visible: true)
 
-      expect(page).to have_css('a', text: /See all 666,666 .* results/)
+      expect(page).to have_css('a', text: /See all 666,666 results/)
 
       within '.searcher-anchors' do
         expect(page).to have_css('a', text: 'Articles+ (666,666)')


### PR DESCRIPTION
Closes #84 

This PR: 
- moves the "See all results" button to the top of the module ands makes it more visible to users
- Changes buttons from 'See all Articles+ results'  to 'See all results'

## Before
![results_button_before](https://user-images.githubusercontent.com/5402927/30715856-a7959f6a-9ecc-11e7-8242-dd720b84f380.png)

## After
![results_button_after](https://user-images.githubusercontent.com/5402927/30715855-a794fb14-9ecc-11e7-83ea-aec853b50e96.png)
