### PR TITLE
add our google_analytics_tracking_id

### DIFF
--- a/config/quick_search_config.yml
+++ b/config/quick_search_config.yml
@@ -28,7 +28,6 @@ defaults: &defaults
   max_per_page: 10
   http_timeout: 1.5
   xhr_http_timeout: 15
-# google_analytics_tracking_id: ""
   user: "stats"
   password: "stats"
 
@@ -76,5 +75,6 @@ staging:
 
 production:
   <<: *defaults
+  google_analytics_tracking_id: "UA-7219229-34"
 #  realtime_url: http://path_to_websockets_server
   # Add or override config options here


### PR DESCRIPTION
This PR fixes #85 

It's sub-optimal as bento-stage will send traffic too (i.e., we're not using shared_configs for the quicksearch yml).