### PR TITLE
Link the logo in the header to '/' so that it routes to…

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
 </div>
 <div id="masthead-container">
   <div id="masthead">
-    <%= link_to root_path do %>
+    <%= link_to '/' do %>
       <%= image_tag 'sul_banner_white.svg', class: 'masthead-logo', alt: 'Stanford Libraries' %>
     <% end %>
   </div>


### PR DESCRIPTION
… library.stanford.edu in production and to the home page in dev.

Will close sul-dlss/SearchWorks#1809