### PR TITLE
Bugfix: module heading template missing value for searcher

### DIFF
--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= service_name.dasherize %>" class="module-contents" >
     <% total = searcher.total.present? ? number_with_delimiter(searcher.total) : nil %>
     <% if searcher.is_a? StandardError %>
-        <%= render partial: 'module_heading', locals: { service_name: service_name, total: total } %>
+        <%= render partial: 'module_heading', locals: { service_name: service_name, total: total, searcher: nil } %>
         <% if params[:page].blank? %>
             <% page = 1 %>
         <% else %>
@@ -9,7 +9,7 @@
         <% end %>
         <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'without_paging' } %>
     <% elsif searcher.results.blank? %>
-        <%= render partial: 'module_heading', locals: { service_name: service_name, total: total } %>
+        <%= render partial: 'module_heading', locals: { service_name: service_name, total: total, searcher: searcher } %>
         <%= render partial: '/quick_search/search/no_results', locals: {module_display_name: module_display_name, service_name: service_name} %>
     <% else %>
         <% unless defined? searcher.loaded_link_mobile %>

--- a/spec/views/quick_search/search/_module_heading.html.erb_spec.rb
+++ b/spec/views/quick_search/search/_module_heading.html.erb_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'quick_search/search/_module_heading.html.erb' do
+  let(:catalog) do
+    double('QuickSearch::CatalogSearcher', loaded_link: 'https://searchworks.stanford.edu/articles?q=climate%20change')
+  end
+  before do
+    without_partial_double_verification do
+      allow(view).to receive(:service_name).and_return('catalog')
+      allow(view).to receive(:total).and_return(0)
+      allow(view).to receive(:searcher).and_return(catalog)
+    end
+    render
+  end
+  it 'renders if there are no results' do
+    expect(rendered).to have_css('.result-set-heading', text: 'Catalog')
+    expect(rendered).to have_css('.result-set-subheading', text: /Books/)
+  end
+end


### PR DESCRIPTION
Hopefully fixes #97 

- Error: modules with zero search results were not loading properly. After #92, the `_module_heading` partial requires that a value  `total` and `searcher` be passed in. No `searcher` value was passed for in the case of `searcher.results.blank?`. 
- Fix: add `searcher` values to remaining instances of `render partial: 'module_heading'`
- Adds a view spec for` _module_heading.html.erb`

## Test search
- [prod](https://library.stanford.edu/all/?utf8=%E2%9C%93&q=%22Rimsky-Korsakov%2C%20Nikolay%2C%201844-1908.%20Skazanie%20o%20nevidimom%20grade%20Kitezhe%20i%20deve%20Fevronii.%22)
- [localhost](http://localhost:3000/all/?utf8=%E2%9C%93&q=%22Rimsky-Korsakov%2C%20Nikolay%2C%201844-1908.%20Skazanie%20o%20nevidimom%20grade%20Kitezhe%20i%20deve%20Fevronii.%22)

## Before
<img width="1001" alt="before_missing_search_results" src="https://user-images.githubusercontent.com/5402927/30757220-b3f5cc6a-9f82-11e7-9414-b369254c7ac1.png">

## After
<img width="985" alt="after_restored_search_results" src="https://user-images.githubusercontent.com/5402927/30757219-b3f5ea2e-9f82-11e7-8563-2875fe07e4fd.png">
