### PR TITLE
Truncate result descriptions to 150 characters.

### DIFF
--- a/app/views/quick_search/search/_result_details.html.erb
+++ b/app/views/quick_search/search/_result_details.html.erb
@@ -3,7 +3,7 @@
 </h3>
 
 <% if result.description.present? %>
-  <p><%= result.description.html_safe %></p>
+  <p><%= truncate(result.description.html_safe, length: Settings.DESCRIPTION_SIZE) %></p>
 <% end %>
 
 <% if result.fulltext_link_html %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,3 +10,4 @@ CATALOG_HOME_URL: 'https://searchworks.stanford.edu'
 ARTICLES_HOME_URL: 'https://searchworks.stanford.edu/articles'
 LIBRARY_WEBSITE_HOME_URL: 'https://library.stanford.edu'
 YEWNO_HOME_URL: 'https://yewno.com/edu'
+DESCRIPTION_SIZE: 150

--- a/spec/views/quick_search/search/_result_details.html.erb_spec.rb
+++ b/spec/views/quick_search/search/_result_details.html.erb_spec.rb
@@ -3,11 +3,12 @@
 require 'rails_helper'
 
 describe 'quick_search/search/_result_details.html.erb' do
+  let(:description) { 'The Description' }
   let(:result) do
     ArticleSearchService::Result.new.tap do |r|
       r.title = 'Title'
       r.link = 'http://example.com'
-      r.description = 'The Description'
+      r.description = description
       r.fulltext_link_html = '<a href="#">Link</a>'
     end
   end
@@ -27,6 +28,16 @@ describe 'quick_search/search/_result_details.html.erb' do
 
   it 'renders the description' do
     expect(rendered).to have_css('p', text: 'The Description')
+  end
+
+  context 'long descriptions' do
+    let(:description) { 'The description ' * 50 }
+
+    it 'are truncated to 150 characters' do
+      text = Capybara.string(rendered).find('p', text: /^The description/).text
+      expect(text.length).to eq 150
+      expect(text).to end_with '...'
+    end
   end
 
   it 'renders the fulltext link html' do


### PR DESCRIPTION
<img width="558" alt="bento-truncate" src="https://user-images.githubusercontent.com/96776/33509314-3436c83e-d6b5-11e7-9c0b-26eac52addc0.png">
