### PR TITLE
Use CGI.escape for query strings

### DIFF
--- a/app/searchers/quick_search/article_searcher.rb
+++ b/app/searchers/quick_search/article_searcher.rb
@@ -7,7 +7,7 @@ module QuickSearch
     end
 
     def loaded_link
-      Settings.EDS_QUERY_URL.to_s % { q: URI.escape(q.to_s) }
+      Settings.EDS_QUERY_URL.to_s % { q: CGI.escape(q.to_s) }
     end
   end
 end

--- a/app/searchers/quick_search/catalog_searcher.rb
+++ b/app/searchers/quick_search/catalog_searcher.rb
@@ -7,7 +7,7 @@ module QuickSearch
     end
 
     def loaded_link
-      Settings.CATALOG_QUERY_URL.to_s % { q: URI.escape(q.to_s) }
+      Settings.CATALOG_QUERY_URL.to_s % { q: CGI.escape(q.to_s) }
     end
   end
 end

--- a/app/searchers/quick_search/library_website_searcher.rb
+++ b/app/searchers/quick_search/library_website_searcher.rb
@@ -7,7 +7,7 @@ module QuickSearch
     end
 
     def loaded_link
-      Settings.LIBRARY_WEBSITE_QUERY_API_URL.to_s % { q: URI.escape(q.to_s) }
+      Settings.LIBRARY_WEBSITE_QUERY_API_URL.to_s % { q: CGI.escape(q.to_s) }
     end
   end
 end

--- a/app/services/abstract_search_service.rb
+++ b/app/services/abstract_search_service.rb
@@ -23,7 +23,7 @@ class AbstractSearchService
 
     # @param [String] `base` is a URL that has format parameters `q` and `max`
     def url(base)
-      base.to_s % { q: URI.escape(q), max: max }
+      base.to_s % { q: CGI.escape(q), max: max }
     end
 
     def q
@@ -116,7 +116,7 @@ class AbstractSearchService
     url = if request_or_query.respond_to?(:url)
             request_or_query.url(@query_url.to_s)
           else
-            @query_url.to_s % { q: URI.escape(request_or_query.to_s), max: Settings.MAX_RESULTS }
+            @query_url.to_s % { q: CGI.escape(request_or_query.to_s), max: Settings.MAX_RESULTS }
           end
 
     response = Faraday.get do |req|


### PR DESCRIPTION
Fixes #111 

This PR fixes an issue where ampersands were not being escaped. 

## Before:
https://library.stanford.edu/all/?utf8=%E2%9C%93&q=Sun+%26+steel
Catalog link: https://searchworks.stanford.edu/?q=Sun%20&%20steel

![sun only results](https://user-images.githubusercontent.com/5402927/34124785-0c314850-e3e9-11e7-9eb3-0668713a6f6d.png)

## After:
http://localhost:3000/all/?utf8=%E2%9C%93&q=Sun+%26+steel
Catalog link: https://searchworks.stanford.edu/?q=Sun%20&%20steel

![sun and steel results](https://user-images.githubusercontent.com/5402927/34124789-10c759c2-e3e9-11e7-8f89-4ff6fd3b2a8c.png)
