### PR TITLE
Update Yewno proxy link

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,4 +10,4 @@ CATALOG_HOME_URL: 'https://searchworks.stanford.edu'
 ARTICLES_HOME_URL: 'https://searchworks.stanford.edu/articles'
 LIBRARY_WEBSITE_HOME_URL: 'https://library.stanford.edu'
 DESCRIPTION_SIZE: 150
-YEWNO_HOME_URL: 'https://stanford.idm.oclc.org/login?url=https://yewno.com/edu'
+YEWNO_HOME_URL: 'https://stanford.idm.oclc.org/login?url=https://discover.yewno.com'

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -21,7 +21,7 @@ feature 'Homepage' do
         text: 'Library website'
       )
       expect(page).to have_css(
-        'a[href="https://stanford.idm.oclc.org/login?url=https://yewno.com/edu"]',
+        'a[href="https://stanford.idm.oclc.org/login?url=https://discover.yewno.com"]', # rubocop:disable LineLength
         text: 'Yewno'
       )
     end


### PR DESCRIPTION
Fixes #125 

This PR updates our Yewno proxy link after a change in their domain name structure.

From the Yewno team:
> How long do I have to update my yewno.com/edu instances and widget to discover.yewno.com on my website or other locations?
> 
> We will guide users to discover.yewno.com for up to 30 days, but you should update your instances as soon as possible to mitigate any gap in coverage when the 30-day date is reached.
> 
> Do I have to whitelist the new discover.yewno.com domain name? 
> a. If you previously whitelisted *yewno.com, then no, you do not have to whitelist the new domain name. If you previously whitelisted yewno.com/edu, then yes, you have to whitelist the new discover.yewno.com domain name.