### PR TITLE
System status wording

### DIFF
--- a/app/views/shared/_services_menu.html.erb
+++ b/app/views/shared/_services_menu.html.erb
@@ -56,6 +56,6 @@
     </ul>
   </li>
   <li>
-    <a role="menuitem" href="https://library-status.stanford.edu/">Searchworks status dashboard</a>
+    <a role="menuitem" href="https://library-status.stanford.edu/">System status</a>
   </li>
 </ul>

--- a/app/views/shared/_sul_footer.html.erb
+++ b/app/views/shared/_sul_footer.html.erb
@@ -12,7 +12,7 @@
           <li><a href="https://library.stanford.edu/myaccount">My Account</a></li>
           <li><a href="https://library.stanford.edu/ask">Ask us</a></li>
           <li><a href="https://library.stanford.edu/opt-out">Opt out of analytics</a></li>
-          <li><a href="https://library-status.stanford.edu/">Searchworks status</a></li>
+          <li><a href="https://library-status.stanford.edu/">System status</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Updated "SearchWorks status" to "System status" in menu & footer to match SW and website.