### PR TITLE
Add global alert configurable via settings

### DIFF
--- a/app/assets/stylesheets/modules/global-alert.scss
+++ b/app/assets/stylesheets/modules/global-alert.scss
@@ -1,0 +1,7 @@
+$global-alert-color: rgb(204, 0, 0);
+
+.global-alert {
+  border: 1px solid $global-alert-color;
+  margin: 10px auto;
+  padding: 10px;
+}

--- a/app/assets/stylesheets/sul-bento.scss
+++ b/app/assets/stylesheets/sul-bento.scss
@@ -5,6 +5,7 @@
 @import 'modules/masthead';
 @import 'modules/subnavbar';
 @import 'modules/top-navbar';
+@import 'modules/global-alert';
 @import 'modules/sul-footer';
 @import 'modules/global-footer';
 

--- a/app/views/layouts/quick_search/application.html.erb
+++ b/app/views/layouts/quick_search/application.html.erb
@@ -53,6 +53,7 @@
               </div>
               <!-- CONTENT: enter content below this line -->
               <div id="quicksearch" class='container'>
+                <%= render '/shared/global_alert' %>
                 <%= yield %>
               </div>
             </main>

--- a/app/views/shared/_global_alert.html.erb
+++ b/app/views/shared/_global_alert.html.erb
@@ -1,0 +1,5 @@
+<% if Settings.GLOBAL_ALERT %>
+  <div class="global-alert">
+    <%= t('global_alert_html') %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   default_title: "Stanford Libraries"
+  global_alert_html: The Stanford Libraries will be operating on a reduced schedule during the Stanford Winter Closure period (December 21, 2019 - January 5, 2020).<br /><a href="https://library.stanford.edu/winterclosure">More information about schedules and affected services</a>
   opensearch_description: "Stanford Libraries"
   defaults_search:
     title_name: Search

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,3 +11,4 @@ ARTICLES_HOME_URL: 'https://searchworks.stanford.edu/articles'
 LIBRARY_WEBSITE_HOME_URL: 'https://library.stanford.edu'
 DESCRIPTION_SIZE: 150
 YEWNO_HOME_URL: 'https://stanford.idm.oclc.org/login?url=https://discover.yewno.com'
+GLOBAL_ALERT: <%= false %>


### PR DESCRIPTION
Closes #233 

This PR: 
- adds a configurable area for global alerts
- sets the alert to this year's winter closure message

![alert on home page](https://user-images.githubusercontent.com/5402927/70757485-9542c380-1cf4-11ea-8d83-cdc28fe5832c.png)
![alert on search results](https://user-images.githubusercontent.com/5402927/70757486-9542c380-1cf4-11ea-9ad1-fd5ac22cf408.png)
