### PR TITLE
Adds a basic Lib Guide search functionality

### DIFF
--- a/app/searchers/quick_search/lib_guides_searcher.rb
+++ b/app/searchers/quick_search/lib_guides_searcher.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module QuickSearch
+  class LibGuidesSearcher < QuickSearch::Searcher
+    delegate :results, :total, :facets, to: :@response
+
+    def search
+      @response ||= ::LibGuidesSearchService.new.search(q)
+    end
+
+    def loaded_link
+      format(Settings.LIBGUIDES.QUERY_URL.to_s, q: CGI.escape(q.to_s))
+    end
+  end
+end

--- a/app/services/lib_guides_search_service.rb
+++ b/app/services/lib_guides_search_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Uses the LibGuides API to search
+class LibGuidesSearchService < AbstractSearchService
+  def initialize(options = {})
+    options[:query_url] ||= query_url
+    options[:response_class] ||= Response
+    super
+  end
+
+  def query_url
+    [
+      Settings.LIBGUIDES.API_URL.to_s,
+      '?',
+      {
+        site_id: Settings.LIBGUIDES.SITE_ID,
+        key: Settings.LIBGUIDES.KEY,
+        status: 1,
+        sort_by: 'relevance',
+      }.to_query,
+      '&search_terms=%{q}'
+    ].join()
+  end
+
+  class Response < AbstractSearchService::Response
+    def results
+      json.collect do |doc|
+        result = AbstractSearchService::Result.new
+        result.title = doc['name']
+        result.link = doc['url']
+        result.id = doc['slug_id']
+        result.description = doc['description']
+        result
+      end
+    end
+
+    def total
+      json.length
+    end
+
+    private
+
+    def json
+      @json ||= JSON.parse(@body)
+    end
+    
+  end
+end

--- a/app/services/lib_guides_search_service.rb
+++ b/app/services/lib_guides_search_service.rb
@@ -24,7 +24,7 @@ class LibGuidesSearchService < AbstractSearchService
 
   class Response < AbstractSearchService::Response
     def results
-      json.collect do |doc|
+      json.first(5).collect do |doc|
         result = AbstractSearchService::Result.new
         result.title = doc['name']
         result.link = doc['url']
@@ -32,6 +32,10 @@ class LibGuidesSearchService < AbstractSearchService
         result.description = doc['description']
         result
       end
+    end
+
+    def facets
+      []
     end
 
     def total

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -44,6 +44,20 @@
   </div>
 </div>
 
+<% if Settings.LIBGUIDES.ENABLED %>
+  <div class="quicksearch-ga-click-tracking">
+    <div class="row">
+      <div class="col-md-6 lib-guides module">
+        <div id="lib-guides" class="module-contents" >
+          <p class="search-error" data-quicksearch-search-endpoint="lib_guides"
+                                  data-quicksearch-page=""
+                                  data-quicksearch-template=""></p>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <div class="quicksearch-ga-click-tracking">
   <%= render partial: 'shared/more_search_tools' %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,9 @@ en:
     error_service_mesasge: "searching SearchWorks articles+"
     no_results_service_message: "a different search"
     no_results_link: "http://searchworks.stanford.edu/articles"
+  lib_guides_search:
+    display_name: Guides
+    sub_heading_html: Wayfinders for our collections, tools, and services
   library_website_search:
     display_name: "Library website"
     short_display_name: "Website"

--- a/config/quick_search_config.yml
+++ b/config/quick_search_config.yml
@@ -18,7 +18,7 @@ defaults: &defaults
   #
   # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
 
-  searchers: [catalog,article,library_website]
+  searchers: [catalog,article,library_website,lib_guides]
 
   # Searchers listed in the "result type guide" bar that lists result types that were found for a given search
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,3 +16,5 @@ LIBGUIDES:
   API_URL: 'https://example.com/1.1/guides'
   SITE_ID: 123456
   KEY: abc1234
+  QUERY_URL: 'TODO'
+  ENABLED: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,3 +12,7 @@ LIBRARY_WEBSITE_HOME_URL: 'https://library.stanford.edu'
 DESCRIPTION_SIZE: 150
 YEWNO_HOME_URL: 'https://stanford.idm.oclc.org/login?url=https://discover.yewno.com'
 GLOBAL_ALERT: <%= false %>
+LIBGUIDES:
+  API_URL: 'https://example.com/1.1/guides'
+  SITE_ID: 123456
+  KEY: abc1234

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,2 @@
+LIBGUIDES:
+  ENABLED: true

--- a/spec/features/lib_guides_spec.rb
+++ b/spec/features/lib_guides_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'LibGuides', js: true do
+  before do
+    response = instance_double(AbstractSearchService::Response, results: [], total: 0)
+    allow_any_instance_of(AbstractSearchService).to receive(:search)
+      .and_return response
+    visit quick_search_path
+  end
+
+  scenario 'is present on index page' do
+    fill_in 'params-q', with: 'geology'
+    click_button 'Search'
+    expect(page).to have_css 'h2', text: 'Guides'
+    page.save_and_open_screenshot
+  end
+end

--- a/spec/searchers/quick_search/lib_guides_searcher_spec.rb
+++ b/spec/searchers/quick_search/lib_guides_searcher_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe QuickSearch::LibGuidesSearcher do
+  subject(:searcher) { described_class.new(instance_double(HTTPClient), query, 10) }
+
+  let(:query) { 'my query' }
+  let(:response) { JSON.dump([]) }
+
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: response))
+  end
+
+  it { expect(searcher).to be_an(QuickSearch::Searcher) }
+  it { expect(searcher.search).to be_an(LibGuidesSearchService::Response) }
+  it do
+    searcher.search # loads response
+    expect(searcher.results).to be_an(Array)
+  end
+end

--- a/spec/services/lib_guides_search_service_spec.rb
+++ b/spec/services/lib_guides_search_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LibGuidesSearchService do
+  subject(:service) { described_class.new }
+
+  let(:response) do
+    JSON.dump([
+      {
+        id: "1050350",
+        name: "World languages education",
+        description: "This guide is for those interested in the teaching of world languages, both research and practice.",
+        redirect_url: "",
+        status: "1",
+        published: "2020-06-15 18:20:56",
+        created: "2020-06-15 16:20:25",
+        updated: "2020-06-15 18:20:56",
+        slug_id: "2081241",
+        slug: "world_languages_ed",
+        friendly_url: "world_languages_ed",
+        nav_type: "0",
+        count_hit: "12",
+        url: "https://guides.library.stanford.edu/c.php?g=1050350",
+        status_label: "Published",
+        type_label: "Topic Guide"
+      }
+    ])
+  end
+  let(:query) { LibGuidesSearchService::Request.new('my query') }
+
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: response))
+  end
+
+  it { expect(service).to be_an AbstractSearchService }
+  it { expect(service.search(query)).to be_an LibGuidesSearchService::Response }
+
+  describe '#query_url' do
+    it 'constructs an API query url' do
+      expect(service.query_url).to eq 'https://example.com/1.1/guides?key=abc1234&site_id=123456&sort_by=relevance&status=1&search_terms=%{q}'
+    end
+  end
+
+  describe '#records' do
+    it 'is set by the fulltext_link_html field in the document' do
+      results = service.search(query).results
+      expect(results.length).to eq 1
+      expect(results.first.title).to eq 'World languages education'
+    end
+  end
+end


### PR DESCRIPTION
Part of #295 

![image](https://user-images.githubusercontent.com/1656824/88949451-7c215f80-d250-11ea-9f6a-d366bf564c94.png)

This sets up the basic building blocks for implementing and working on lib guides. I'm not exactly sure of the page layout, but this is feature flagged so perhaps we can iterate on that?