### PR TITLE
Update highlighted-facet to use the same structure as the 'found  res…

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -51,24 +51,29 @@ h4 {
   line-height: 1.2em;
 }
 
-dl {
-  margin-bottom: 15px;
-}
-
 dt {
-  color: $cool-grey;
   font-weight: normal;
-  font-size: .9em;
   text-transform: uppercase !important;
-  padding-right: 1em;
-  padding-top: .15em;
-  width: 12em;
 }
 
-dd {
-  margin-left: 2em;
-  margin-bottom: .5em;
-  max-width: 45em;
+#result-types {
+  dl {
+    margin-bottom: 15px;
+  }
+
+  dt {
+    color: $cool-grey;
+    font-size: .9em;
+    padding-right: 1em;
+    padding-top: .15em;
+    width: 12em;
+  }
+
+  dd {
+    margin-left: 2em;
+    margin-bottom: .5em;
+    max-width: 45em;
+  }
 }
 
 label {

--- a/app/assets/stylesheets/modules/highlighted_facet.scss
+++ b/app/assets/stylesheets/modules/highlighted_facet.scss
@@ -3,6 +3,5 @@
 
   .includes-label {
     margin-right: 15px;
-    text-transform: uppercase;
   }
 }

--- a/app/assets/stylesheets/modules/results.scss
+++ b/app/assets/stylesheets/modules/results.scss
@@ -7,10 +7,6 @@
   ol { padding-left: 18px; }
 }
 
-.highlighted-facet {
-  padding-bottom: 20px;
-}
-
 .result-set-subheading {
   font-size: 14px;
   padding-bottom: 10px;

--- a/app/views/quick_search/search/_highlighted_facet.html.erb
+++ b/app/views/quick_search/search/_highlighted_facet.html.erb
@@ -1,12 +1,14 @@
 <% if searcher.search.highlighted_facet_values.present? %>
-  <% element_id = searcher.class.name.underscore.parameterize %>
-  <div class='highlighted-facet'>
-    <span class="includes-label" id="<%= element_id %>">Results include</span>
-    <% searcher.search.highlighted_facet_values.each_with_index do |facet, index| %>
-      <%= "&middot;".html_safe unless index == 0 %>
-      <span aria-labelledby="<%= element_id %>">
-        <%= link_to("#{facet.label} (#{number_with_delimiter(facet.hits)})", facet.query_url(params[:q])) %>
-      </span>
-    <% end %>
-  </div>
+  <dl class='highlighted-facet d-flex'>
+    <dt class="includes-label">Results include</dt>
+    <dd>
+      <ul class="list-inline mb-0">
+        <% searcher.search.highlighted_facet_values.each_with_index do |facet, index| %>
+          <li class="list-inline-item">
+            <%= link_to("#{facet.label} (#{number_with_delimiter(facet.hits)})", facet.query_url(params[:q])) %>
+          </li>
+        <% end %>
+      </ul>
+    </dd>
+  </dl>
 <% end %>


### PR DESCRIPTION
…ults in' section; fixes #292.

<img width="584" alt="Screen Shot 2020-08-03 at 09 18 16" src="https://user-images.githubusercontent.com/111218/89204007-4a6b0a00-d56a-11ea-901b-9f6504f3e1fa.png">
