### PR TITLE
Pull in temporary access links from the catalog API.

### DIFF
--- a/app/assets/stylesheets/modules/results.scss
+++ b/app/assets/stylesheets/modules/results.scss
@@ -41,6 +41,15 @@
   text-overflow: ellipsis;
 }
 
+.etas-notice {
+  color: $sul-availability-notice-color;
+}
+
+.etas-results-block {
+  border: 3px solid $sul-temp-access-alert-box-border-color;
+  padding: 8px;
+}
+
 @include media-breakpoint-down(md) {
   .result-set-heading,
   .result-set-subheading {

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -83,3 +83,5 @@ $sul-btn-disabled-opacity: 0.9;
 $sul-main-title-date-color: $cool-grey;
 $sul-tooltip-bg: $lagunita;
 $sul-shadow-color: rgba(0, 0, 0, .2);
+$sul-availability-notice-color: $cardinal-red;
+$sul-temp-access-alert-box-border-color: $poppy;

--- a/app/services/abstract_search_service.rb
+++ b/app/services/abstract_search_service.rb
@@ -96,7 +96,7 @@ class AbstractSearchService
   end
 
   class Result
-    ATTRS = %i[author title imprint description link id thumbnail breadcrumbs fulltext_link_html].freeze
+    ATTRS = %i[author title imprint description link id thumbnail breadcrumbs fulltext_link_html temporary_access_link_html].freeze
     attr_accessor *ATTRS
 
     def to_h

--- a/app/services/catalog_search_service.rb
+++ b/app/services/catalog_search_service.rb
@@ -26,6 +26,7 @@ class CatalogSearchService < AbstractSearchService
         result.author = doc['author_person_display']&.first
         result.imprint = doc['imprint_display']&.first
         result.fulltext_link_html = doc['fulltext_link_html']&.first
+        result.temporary_access_link_html = doc['temporary_access_link_html']&.first
         result.id = doc['id']
 
         result.description = doc['summary_display'].try(:join) || find_description_in_marcxml(doc['marcbib_xml'])

--- a/app/views/quick_search/search/_result_details.html.erb
+++ b/app/views/quick_search/search/_result_details.html.erb
@@ -17,6 +17,14 @@
   <p class="description"><%= result.description.html_safe %></p>
 <% end %>
 
+<% if result.temporary_access_link_html.present? %>
+  <%= result.temporary_access_link_html.html_safe %>
+  <div class="etas-results-block">
+    <p class="etas-notice">Available to students, faculty, and staff, by special arrangement in response to COVID-19. To protect our access to ETAS, the physical copy is temporarily not requestable.</p>
+    <%= link_to('More about HathiTrust ETAS', 'https://www.hathitrust.org/ETAS-User-Information') %>
+  </div>
+<% end %>
+
 <% if result.fulltext_link_html %>
   <p><%= result.fulltext_link_html.html_safe %></p>
 <% end %>


### PR DESCRIPTION
Closes #306 

This is assuming sul-dlss/SearchWorks#2512 is shipped and available 

<img width="568" alt="Screen Shot 2020-08-03 at 9 51 24 AM" src="https://user-images.githubusercontent.com/96776/89207054-fdd5fd80-d56e-11ea-84eb-b56caf3578ff.png">
