### PR TITLE
Add i18n keys for lib guides used on the no-results version of the …

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,8 @@ en:
     no_results_link: "http://searchworks.stanford.edu/articles"
   lib_guides_search:
     display_name: Guides
+    micro_display_name: guide
+    no_results_service_message: "a different search"
     sub_heading_html: Wayfinders for our collections, tools, and services
   library_website_search:
     display_name: "Library website"


### PR DESCRIPTION
…bento box.

Closes #309 

<img width="568" alt="no-results-lib-guides" src="https://user-images.githubusercontent.com/96776/89240758-e409da00-d5b1-11ea-8fbc-d39520ea6ed0.png">
