### PR TITLE
Enables support for new library website JSON api

### DIFF
--- a/app/searchers/quick_search/library_website_api_searcher.rb
+++ b/app/searchers/quick_search/library_website_api_searcher.rb
@@ -9,7 +9,7 @@ module QuickSearch
     end
 
     def loaded_link
-      format(Settings.LIBRARY_WEBSITE_QUERY_API_URL.to_s, q: CGI.escape(q.to_s))
+      format(Settings.LIBRARY_WEBSITE.QUERY_URL.to_s, q: CGI.escape(q.to_s))
     end
   end
 end

--- a/app/searchers/quick_search/library_website_api_searcher.rb
+++ b/app/searchers/quick_search/library_website_api_searcher.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module QuickSearch
+  class LibraryWebsiteApiSearcher < QuickSearch::Searcher
+    delegate :results, :total, :facets, to: :@response
+
+    def search
+      @response ||= ::LibraryWebsiteApiSearchService.new.search(q)
+    end
+
+    def loaded_link
+      format(Settings.LIBRARY_WEBSITE_QUERY_API_URL.to_s, q: CGI.escape(q.to_s))
+    end
+  end
+end

--- a/app/services/library_website_api_search_service.rb
+++ b/app/services/library_website_api_search_service.rb
@@ -3,7 +3,7 @@
 # Uses the Library Website API to search
 class LibraryWebsiteApiSearchService < AbstractSearchService
   def initialize(options = {})
-    options[:query_url] ||= Settings.LIBRARY_WEBSITE_JSON_API_URL.to_s
+    options[:query_url] ||= Settings.LIBRARY_WEBSITE.API_URL.to_s
     options[:response_class] ||= Response
     super
   end
@@ -17,7 +17,7 @@ class LibraryWebsiteApiSearchService < AbstractSearchService
   class Response < AbstractSearchService::Response
     HIGHLIGHTED_FACET_FIELD = 'format_facet'
     HIGHLIGHTED_FACET_CLASS = LibraryWebsiteApiSearchService::HighlightedFacetItem
-    QUERY_URL = Settings.LIBRARY_WEBSITE_QUERY_API_URL.freeze
+    QUERY_URL = Settings.LIBRARY_WEBSITE.QUERY_URL.freeze
 
     def results
       Array.wrap(json['results']).first(3).collect do |doc|

--- a/app/services/library_website_api_search_service.rb
+++ b/app/services/library_website_api_search_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Uses the Library Website API to search
+class LibraryWebsiteApiSearchService < AbstractSearchService
+  def initialize(options = {})
+    options[:query_url] ||= Settings.LIBRARY_WEBSITE_JSON_API_URL.to_s
+    options[:response_class] ||= Response
+    super
+  end
+
+  class HighlightedFacetItem < AbstractSearchService::HighlightedFacetItem
+    def facet_field_to_param
+      "f[0]=#{CGI.escape(value)}"
+    end
+  end
+
+  class Response < AbstractSearchService::Response
+    HIGHLIGHTED_FACET_FIELD = 'format_facet'
+    HIGHLIGHTED_FACET_CLASS = LibraryWebsiteApiSearchService::HighlightedFacetItem
+    QUERY_URL = Settings.LIBRARY_WEBSITE_QUERY_API_URL.freeze
+
+    def results
+      Array.wrap(json['results']).first(3).collect do |doc|
+        result = AbstractSearchService::Result.new
+        result.title = doc['title']
+        result.link = doc['url']
+        result.description = doc['description']
+        result
+      end
+    end
+
+    def facets
+      facet_response = [{
+        'name' => HIGHLIGHTED_FACET_FIELD
+      }]
+      facet_response.first['items'] = json['facets']['items'].map do |facet|
+        {
+          'value' => facet['term']&.first,
+          'label' => facet['label'],
+          'hits' => facet['hits'],
+        }
+      end
+      facet_response
+    end
+
+    def total
+      nil
+    end
+
+    private
+
+    def json
+      # Force UTF-8 as the API returns BOM
+      @json ||= JSON.parse(
+        @body.gsub("\xEF\xBB\xBF".dup.force_encoding(Encoding::BINARY), '')
+      )
+    end
+    
+  end
+end

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -35,13 +35,22 @@
       </div>
     </div>
   <% end %>
-  <div class="col library-website module">
-    <div id="library-website" class="module-contents" tabindex="-1">
-      <p class="search-error" data-quicksearch-search-endpoint="library_website"
-                              data-quicksearch-page=""
-                              data-quicksearch-template=""></p>
+
+    <div class="col library-website module">
+      <% if Settings.ENABLED_SEARCHERS.include?('library_website_api') %>
+        <div id="library-website-api" class="module-contents" tabindex="-1">
+          <p class="search-error" data-quicksearch-search-endpoint="library_website_api"
+                                  data-quicksearch-page=""
+                                  data-quicksearch-template=""></p>
+        </div>
+      <% else %>
+        <div id="library-website" class="module-contents" tabindex="-1">
+          <p class="search-error" data-quicksearch-search-endpoint="library_website"
+                                  data-quicksearch-page=""
+                                  data-quicksearch-template=""></p>
+        </div>
+      <% end %>  
     </div>
-  </div>
 
   <% if Settings.ENABLED_SEARCHERS.include?('exhibits') %>
     <div class="col exhibits module">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,5 +56,15 @@ en:
     no_results_link: "http://library.stanford.edu/search/website"
   yewno:
     sub_heading_html: Knowledge graphs for interconnecting concepts.
+  library_website_api_search:
+    display_name: "Library website"
+    short_display_name: "Website"
+    sub_heading_html: "Library info; guides & content by subject specialists"
+    micro_display_name: "website"
+    search_form_placeholder: "Search Library website"
+    module_callout: "Search Library website"
+    error_service_mesasge: "searching library website"
+    no_results_service_message: "a different search"
+    no_results_link: "http://library.stanford.edu/search/website"
   search_form:
     placeholder: "catalog + articles + website + more"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,3 @@
-LIBRARY_WEBSITE_JSON_API_URL: 'https://library.stanford.edu/bento?keys=%{q}'
 LIBRARY_WEBSITE_QUERY_API_URL: 'https://library.stanford.edu/search/website?search=%{q}'
 MAX_RESULTS: 3
 
@@ -32,3 +31,6 @@ EXHIBITS:
   LINK_URL: 'https://exhibits.stanford.edu/%{id}'
   NUM_RESULTS_SHOWN: 3
   QUERY_URL: 'https://exhibits.stanford.edu/search?q=%{q}'
+LIBRARY_WEBSITE:
+  API_URL: 'https://library.stanford.edu/bento?keys=%{q}'
+  QUERY_URL: 'https://library.stanford.edu/search/website?search=%{q}'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,4 @@
+LIBRARY_WEBSITE_JSON_API_URL: 'https://library.stanford.edu/bento?keys=%{q}'
 LIBRARY_WEBSITE_QUERY_API_URL: 'https://library.stanford.edu/search/website?search=%{q}'
 MAX_RESULTS: 3
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,5 +2,5 @@ ENABLED_SEARCHERS:
   - catalog
   - article
   - lib_guides
-  - library_website
+  - library_website_api
   - exhibits

--- a/spec/searchers/quick_search/library_website_api_searcher_spec.rb
+++ b/spec/searchers/quick_search/library_website_api_searcher_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe QuickSearch::LibraryWebsiteApiSearcher do
+  subject(:searcher) { described_class.new(instance_double(HTTPClient), query, 10) }
+
+  let(:query) { 'my query' }
+  let(:body) do
+    {
+      results: [
+        {
+          title: 'Chinese art: Traditional',
+          url: 'https://library.stanford.edu/guides/chinese-art-traditional',
+          description: 'This guide...'
+        }
+      ]
+    }
+  end
+
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: body.to_json))
+  end
+
+  it { expect(searcher).to be_an(QuickSearch::Searcher) }
+  it { expect(searcher.search).to be_an(LibraryWebsiteApiSearchService::Response) }
+  it do
+    searcher.search # loads response
+    expect(searcher.results).to be_an(Array)
+  end
+end

--- a/spec/services/library_website_api_search_service_spec.rb
+++ b/spec/services/library_website_api_search_service_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LibraryWebsiteApiSearchService do
+  subject(:service) { described_class.new }
+
+  let(:response) do
+    JSON.dump({
+      results: [
+        {
+          title: 'Chinese art: Traditional',
+          url: 'https://library.stanford.edu/guides/chinese-art-traditional',
+          description: 'This guide...'
+        }
+      ],
+      facets: {
+        name: 'format_facet',
+        items: [
+          {
+            value: 'blog',
+            label: 'Blog',
+            hits: 32,
+            term: ['type:blog']
+          }
+        ]
+      }
+    })
+  end
+  let(:query) { LibraryWebsiteApiSearchService::Request.new('chinese art') }
+
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: response))
+  end
+
+  it { expect(service).to be_an AbstractSearchService }
+  it { expect(service.search(query)).to be_an LibraryWebsiteApiSearchService::Response }
+
+  describe '#facets' do
+    it 'constructs an API query url' do
+      facets = service.search(query).facets
+      expect(facets.first).to eq({
+        'name' => 'format_facet',
+        'items' => [{ 'hits' => 32, 'label' => 'Blog', 'value' => 'type:blog' }]
+      })
+    end
+  end
+
+  describe '#records' do
+    it 'sets the title in the document' do
+      results = service.search(query).results
+      expect(results.length).to eq 1
+      expect(results.first.title).to eq 'Chinese art: Traditional'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #104  part of evaluation in #105 

Analysis of current JSON api here: https://github.com/sul-dlss/sul-bento-app/issues/105#issuecomment-668794602

This is built in a way so that it could be released via a configuration.

![Screen Shot 2020-08-04 at 2 44 31 PM](https://user-images.githubusercontent.com/1656824/89343100-03ac0b80-d661-11ea-946c-b85799fc9f19.png)
