### PR TITLE
Add an Exhibits bento box

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,5 +17,6 @@
 //= require popper
 //= require bootstrap-sprockets
 //= require yewno
+//= require toggleableResults
 
 jQuery.migrateMute = true

--- a/app/assets/javascripts/toggleableResults.js
+++ b/app/assets/javascripts/toggleableResults.js
@@ -1,0 +1,25 @@
+function toggleableResults(searcher) {
+  var toggleableResults = $('#' + searcher + ' [data-behavior="toggleable-results"]');
+  var threshold = toggleableResults.data('toggleThreshold');
+  var toggleButton = $('#' + searcher + '-results-toggle-button');
+  var listItemsBeyondThreshold = toggleableResults.find('li:nth-child(n+' + (threshold + 1) + ')');
+
+  listItemsBeyondThreshold.toggle();
+
+  toggleButton.data('opened', false);
+  toggleButton.on('click', function() {
+    toggleButton.data('opened', !toggleButton.data('opened'));
+
+    listItemsBeyondThreshold.slideToggle();
+
+    if (toggleButton.data('opened')) {
+      toggleButton.text(' Show fewer');
+      toggleButton.prepend('<i class="fa fa-chevron-up"></i>')
+      toggleButton.attr('aria-expanded', true);
+    } else {
+      toggleButton.text(' ' + toggleButton.data('originalText'));
+      toggleButton.prepend('<i class="fa fa-chevron-down"></i>')
+      toggleButton.attr('aria-expanded', false);
+    }
+  });
+}

--- a/app/assets/stylesheets/modules/results.scss
+++ b/app/assets/stylesheets/modules/results.scss
@@ -28,6 +28,10 @@
   }
 }
 
+.pass-on-search-link {
+  margin-top: .5rem;
+}
+
 .description {
   -webkit-box-orient: vertical;
   box-orient: vertical;

--- a/app/searchers/quick_search/exhibits_searcher.rb
+++ b/app/searchers/quick_search/exhibits_searcher.rb
@@ -11,5 +11,13 @@ module QuickSearch
     def loaded_link
       format(Settings.EXHIBITS.QUERY_URL.to_s, q: CGI.escape(q.to_s))
     end
+
+    def togglable?
+      true
+    end
+
+    def toggle_threshold
+      Settings.EXHIBITS.NUM_RESULTS_SHOWN
+    end
   end
 end

--- a/app/searchers/quick_search/exhibits_searcher.rb
+++ b/app/searchers/quick_search/exhibits_searcher.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module QuickSearch
+  class ExhibitsSearcher < QuickSearch::Searcher
+    delegate :results, :total, :facets, to: :@response
+
+    def search
+      @response ||= ::ExhibitsSearchService.new.search(q)
+    end
+
+    def loaded_link
+      format(Settings.EXHIBITS.QUERY_URL.to_s, q: CGI.escape(q.to_s))
+    end
+  end
+end

--- a/app/searchers/quick_search/exhibits_searcher.rb
+++ b/app/searchers/quick_search/exhibits_searcher.rb
@@ -12,7 +12,7 @@ module QuickSearch
       format(Settings.EXHIBITS.QUERY_URL.to_s, q: CGI.escape(q.to_s))
     end
 
-    def togglable?
+    def toggleable?
       true
     end
 

--- a/app/services/exhibits_search_service.rb
+++ b/app/services/exhibits_search_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Uses the LibGuides API to search
+class ExhibitsSearchService < AbstractSearchService
+  def initialize(options = {})
+    options[:query_url] ||= Settings.EXHIBITS.API_URL.to_s
+    options[:response_class] ||= Response
+    super
+  end
+
+  class Response < AbstractSearchService::Response
+    def results
+      json.collect do |exhibit|
+        result = AbstractSearchService::Result.new
+        result.title = exhibit['title']
+        result.link = format(Settings.EXHIBITS.LINK_URL.to_s, id: exhibit['slug'])
+        result.description = exhibit['subtitle']
+        result
+      end
+    end
+
+    def facets
+      []
+    end
+
+    def total
+      json.length
+    end
+
+    private
+
+    def json
+      @json ||= JSON.parse(@body)
+    end
+  end
+end

--- a/app/services/exhibits_search_service.rb
+++ b/app/services/exhibits_search_service.rb
@@ -15,6 +15,7 @@ class ExhibitsSearchService < AbstractSearchService
         result.title = exhibit['title']
         result.link = format(Settings.EXHIBITS.LINK_URL.to_s, id: exhibit['slug'])
         result.description = exhibit['subtitle']
+        result.thumbnail = exhibit['thumbnail_url']
         result
       end
     end

--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -16,7 +16,7 @@
         <%= render partial: 'module_heading', locals: { service_name: service_name, total: total, searcher: searcher } %>
 
         <%= render partial: '/quick_search/search/highlighted_facet', locals: { searcher: searcher } %>
-        <ol>
+        <ol id="<%= service_name %>-toggleable-results" <%= "data-behavior=\"toggleable-results\" data-toggle-threshold=\"#{searcher.toggle_threshold}\"".html_safe if defined?(searcher.toggleable?) && searcher.toggleable? %>>
           <%= render partial: '/quick_search/search/result', collection: searcher.results %>
         </ol>
 
@@ -25,6 +25,22 @@
             Your search also found
             <%= link_to("#{number_with_delimiter(addl_facet.hits)} topic specific databases", addl_facet.href) %>.
           </p>
+        <% end %>
+
+        <% if defined?(searcher.toggleable?) && searcher.toggleable? %>
+          <% if searcher.total.to_i > searcher.toggle_threshold.to_i %>
+            <button aria-expanded="false" aria-controls="<%= service_name %>-toggleable-results" data-original-text="<%= I18n.t("#{service_name}_search.toggle_button_text", total: searcher.total) %>" id="<%= service_name %>-results-toggle-button" class="btn btn-cardinal-red">
+              <i class="fa fa-chevron-down"></i> <%= I18n.t("#{service_name}_search.toggle_button_text", total: searcher.total) %>
+            </button>
+
+            <script type='text/javascript'>
+              toggleableResults('<%= service_name %>');
+            </script>
+          <% end %>
+
+          <div class="mt-3">
+            <i class="fa fa-external-link"></i> <%= link_to(I18n.t("#{service_name}_search.pass_on_search_link_text", query: searcher.q), searcher.loaded_link) %>
+          </div>
         <% end %>
 
         <% if searcher.total.present? %>

--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -13,15 +13,11 @@
         <%= render partial: 'module_heading', locals: { service_name: service_name, total: total, searcher: searcher } %>
         <%= render partial: '/quick_search/search/no_results', locals: {module_display_name: module_display_name, service_name: service_name, searcher: searcher} %>
     <% else %>
-        <% unless defined? searcher.loaded_link_mobile %>
-          <%= render partial: 'module_heading', locals: { service_name: service_name, total: total, searcher: searcher } %>
-        <% else %>
-          <%= render partial: 'module_heading', locals: { service_name: service_name, total: total, searcher: searcher } %>
-        <% end %>
-        <%= render partial: '/quick_search/search/highlighted_facet', locals: { searcher: searcher } %>
+        <%= render partial: 'module_heading', locals: { service_name: service_name, total: total, searcher: searcher } %>
 
+        <%= render partial: '/quick_search/search/highlighted_facet', locals: { searcher: searcher } %>
         <ol>
-            <%= render partial: '/quick_search/search/result', collection: searcher.results %>
+          <%= render partial: '/quick_search/search/result', collection: searcher.results %>
         </ol>
 
         <% if (addl_facet = searcher.search.additional_facet_details(params[:q])) %>

--- a/app/views/quick_search/search/_module_heading.html.erb
+++ b/app/views/quick_search/search/_module_heading.html.erb
@@ -4,18 +4,20 @@
       <%= I18n.t("#{service_name}_search.display_name") %>
     </h2>
   </div>
-  <div class="col-md-7 see-all-results">
-    <% unless defined? searcher.loaded_link_mobile %>
-      <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link} %>
-    <% else %>
-      <span class="show-for-medium-up">
+  <% unless (defined?(searcher.toggleable?) && searcher.toggleable?)  %>
+    <div class="col-md-7 see-all-results">
+      <% unless defined? searcher.loaded_link_mobile %>
         <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link} %>
-      </span>
-      <span class="show-for-small-only">
-        <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link_mobile} %>
-      </span>
-    <% end %>
-  </div>
+      <% else %>
+        <span class="show-for-medium-up">
+          <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link} %>
+        </span>
+        <span class="show-for-small-only">
+          <%= render partial: '/quick_search/search/see_all', locals: {service_name: service_name, total: total, module_link: searcher.loaded_link_mobile} %>
+        </span>
+      <% end %>
+    </div>
+  <% end %>
 </div>
 <span class='h3 result-set-subheading'>
   <%= I18n.t("#{service_name}_search.sub_heading_html") %>

--- a/app/views/quick_search/search/_result_with_thumbnail.html.erb
+++ b/app/views/quick_search/search/_result_with_thumbnail.html.erb
@@ -1,0 +1,23 @@
+<div class="row mb-3">
+  <% unless defined? result.mobile_link %>
+      <div class="col-sm-3">
+          <%= link_to result.link do %>
+              <%= image_tag result.thumbnail, :class => 'thumbnail img-fluid' %>
+          <% end %>
+      </div>
+  <% else %>
+      <div class="col-sm-3 columns show-for-medium-up">
+          <%= link_to result.link do %>
+              <%= image_tag result.thumbnail, :class => 'thumbnail img-fluid' %>
+          <% end %>
+      </div>
+      <div class="col-sm-3 columns show-for-small-only">
+          <%= link_to result.mobile_link do %>
+              <%= image_tag result.thumbnail, :class => 'thumbnail img-fluid' %>
+          <% end %>
+      </div>
+  <% end %>
+  <div class="col-sm-9 columns">
+      <%= render partial: '/quick_search/search/result_details', locals: { result: result } %>
+  </div>
+</div>

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -44,9 +44,10 @@
   </div>
 </div>
 
-<% if Settings.ENABLED_SEARCHERS.include?('lib_guides') %>
-  <div class="quicksearch-ga-click-tracking">
-    <div class="row">
+
+<div class="quicksearch-ga-click-tracking">
+  <div class="row">
+    <% if Settings.ENABLED_SEARCHERS.include?('lib_guides') %>
       <div class="col-md-6 lib-guides module">
         <div id="lib-guides" class="module-contents" >
           <p class="search-error" data-quicksearch-search-endpoint="lib_guides"
@@ -54,9 +55,20 @@
                                   data-quicksearch-template=""></p>
         </div>
       </div>
-    </div>
+    <% end %>
+
+    <% if Settings.ENABLED_SEARCHERS.include?('exhibits') %>
+      <div class="col-md-6 exhibits module">
+        <div id="exhibits" class="module-contents" >
+          <p class="search-error" data-quicksearch-search-endpoint="exhibits"
+                                  data-quicksearch-page=""
+                                  data-quicksearch-template=""></p>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>
+
 
 <div class="quicksearch-ga-click-tracking">
   <%= render partial: 'shared/more_search_tools' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,11 @@
 en:
   default_title: "Stanford Libraries"
+  exhibits_search:
+    short_display_name: Exhibits
+    display_name: Exhibits
+    micro_display_name: exhibits
+    no_results_service_message: "a different search"
+    sub_heading_html: Digital showcase for research and teaching
   global_alert_html: >
     <b>RESEARCH RESTART</b><br/>
     The Libraries are resuming limited in-person research activities <a href="https://mylibrary.stanford.edu">by appointment only</a> as part of the University's <a href="https://cardinalrecovery.stanford.edu/research/research-recovery/">Research Restart Plan</a>.<br/>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,9 @@ en:
     display_name: Exhibits
     micro_display_name: exhibits
     no_results_service_message: "a different search"
+    pass_on_search_link_text: Search "%{query}" in all exhibit items
     sub_heading_html: Digital showcase for research and teaching
+    toggle_button_text: Show %{total} exhibits
   global_alert_html: >
     <b>RESEARCH RESTART</b><br/>
     The Libraries are resuming limited in-person research activities <a href="https://mylibrary.stanford.edu">by appointment only</a> as part of the University's <a href="https://cardinalrecovery.stanford.edu/research/research-recovery/">Research Restart Plan</a>.<br/>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,4 +25,5 @@ LIBGUIDES:
 EXHIBITS:
   API_URL: 'https://exhibits.stanford.edu/exhibit_finder?q=%{q}'
   LINK_URL: 'https://exhibits.stanford.edu/%{id}'
+  NUM_RESULTS_SHOWN: 5
   QUERY_URL: 'https://exhibits.stanford.edu/search?q=%{q}'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,3 +21,8 @@ LIBGUIDES:
   KEY: abc1234
   QUERY_URL: 'TODO'
   HOME_URL: 'https://guides.library.stanford.edu/'
+
+EXHIBITS:
+  API_URL: 'https://exhibits.stanford.edu/exhibit_finder?q=%{q}'
+  LINK_URL: 'https://exhibits.stanford.edu/%{id}'
+  QUERY_URL: 'https://exhibits.stanford.edu/search?q=%{q}'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,3 +3,4 @@ ENABLED_SEARCHERS:
   - article
   - lib_guides
   - library_website
+  - exhibits

--- a/spec/features/exhibits_spec.rb
+++ b/spec/features/exhibits_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Exhibits', js: true do
+  let(:results) do
+    10.times.map do |i|
+      AbstractSearchService::Result.new.tap do |result|
+        result.title = "Exhibit title #{i}"
+        result.link = "https://www.example.com/#{i}"
+        result.description = "The description for Exhibit #{i}"
+      end
+    end
+  end
+
+  before do
+    response = instance_double(
+      AbstractSearchService::Response,
+      results: results,
+      total: results.length,
+      highlighted_facet_values: [],
+      additional_facet_details: nil
+    )
+    allow_any_instance_of(AbstractSearchService).to receive(:search)
+      .and_return response
+    visit quick_search_path
+  end
+
+  scenario 'is present on index page' do
+    fill_in 'params-q', with: 'Photography'
+    click_button 'Search'
+
+    within('#exhibits') do
+      expect(page).to have_css('ol li', count: 10, visible: :all)
+      expect(page).to have_css('ol li', count: 5, visible: :visible)
+      expect(page).to have_css('ol li', count: 5, visible: :hidden)
+
+      click_button 'Show 10 exhibits'
+      expect(page).to have_css('ol li', count: 10, visible: :visible)
+      expect(page).to have_css('ol li', count: 0, visible: :hidden)
+
+      click_button 'Show fewer'
+      expect(page).to have_css('ol li', count: 10, visible: :all)
+      expect(page).to have_css('ol li', count: 5, visible: :visible)
+      expect(page).to have_css('ol li', count: 5, visible: :hidden)
+
+      expect(page).to have_button('Show 10 exhibits')
+      expect(page).not_to have_button('Show fewer')
+    end
+  end
+end

--- a/spec/searchers/quick_search/exhibits_searcher_spec.rb
+++ b/spec/searchers/quick_search/exhibits_searcher_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe QuickSearch::ExhibitsSearcher do
+  subject(:searcher) { described_class.new(instance_double(HTTPClient), query, 10) }
+
+  let(:query) { 'my query' }
+  let(:response) { JSON.dump([]) }
+
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: response))
+  end
+
+  it { expect(searcher).to be_an(QuickSearch::Searcher) }
+  it { expect(searcher.search).to be_an(ExhibitsSearchService::Response) }
+  it { expect(searcher).to be_toggleable }
+  it { expect(searcher.toggle_threshold).to be 5 }
+
+  it do
+    searcher.search # loads response
+    expect(searcher.results).to be_an(Array)
+  end
+end

--- a/spec/services/exhibits_search_service_spec.rb
+++ b/spec/services/exhibits_search_service_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExhibitsSearchService do
+  subject(:service) { described_class.new }
+
+  let(:response) do
+    JSON.dump([
+      {
+        title: 'Exhibit Title',
+        slug: 'exhibit-slug',
+        subtitle: 'The subtitle of the exhibit',
+        thumbnail_url: 'https://example.com/kitten.jpg'
+      }
+    ])
+  end
+  let(:query) { ExhibitsSearchService::Request.new('my query') }
+
+  before do
+    allow(Faraday).to receive(:get).and_return(instance_double(Faraday::Response,
+                                                               success?: true,
+                                                               body: response))
+  end
+
+  it { expect(service).to be_an AbstractSearchService }
+  it { expect(service.search(query)).to be_an ExhibitsSearchService::Response }
+
+  describe '#records' do
+    it 'returns the relevant metadata from the API' do
+      results = service.search(query).results
+      expect(results.length).to eq 1
+      expect(results.first.title).to eq 'Exhibit Title'
+      expect(results.first.description).to eq 'The subtitle of the exhibit'
+      expect(results.first.link).to eq 'https://exhibits.stanford.edu/exhibit-slug'
+      expect(results.first.thumbnail).to eq 'https://example.com/kitten.jpg'
+    end
+  end
+end


### PR DESCRIPTION
Closes #298

### TODO
- [x] Implement the ability to define a searcher as one that toggles results instead of showing the first N.
- [x] Add the ability to link to the items search for exhibits (prob. either piggy back on "loaded_link" or add something new).
...


## Query: `Photography`
_**Note:** I locally configured the threshold to 2 just to get the toggle functionality showing (since we're currently limiting the API results to 5, which will be addressed on the next deploy to Exhibits)._

![exhibits-bento-box](https://user-images.githubusercontent.com/96776/89478867-311eb500-d746-11ea-8ae8-8a244b0c5532.gif)

