### PR TITLE
Don't remove the focus outline for the search scope dropdown

### DIFF
--- a/app/assets/stylesheets/modules/masthead.scss
+++ b/app/assets/stylesheets/modules/masthead.scss
@@ -25,7 +25,6 @@
     }
 
     &:hover, &:focus {
-      outline: 0;
       text-decoration: none;
     }
   }


### PR DESCRIPTION
Part of (fixes?) #333