### PR TITLE
Enable LibGuides results to be toggleable.

### DIFF
--- a/app/searchers/quick_search/lib_guides_searcher.rb
+++ b/app/searchers/quick_search/lib_guides_searcher.rb
@@ -11,5 +11,13 @@ module QuickSearch
     def loaded_link
       format(Settings.LIBGUIDES.QUERY_URL.to_s, q: CGI.escape(q.to_s))
     end
+
+    def toggleable?
+      true
+    end
+
+    def toggle_threshold
+      Settings.LIBGUIDES.NUM_RESULTS_SHOWN
+    end
   end
 end

--- a/app/services/lib_guides_search_service.rb
+++ b/app/services/lib_guides_search_service.rb
@@ -24,7 +24,7 @@ class LibGuidesSearchService < AbstractSearchService
 
   class Response < AbstractSearchService::Response
     def results
-      json.first(5).collect do |doc|
+      json.collect do |doc|
         result = AbstractSearchService::Result.new
         result.title = doc['name']
         result.link = doc['url']
@@ -47,6 +47,6 @@ class LibGuidesSearchService < AbstractSearchService
     def json
       @json ||= JSON.parse(@body)
     end
-    
+
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,9 @@ en:
     display_name: Guides
     micro_display_name: guide
     no_results_service_message: "a different search"
+    pass_on_search_link_text: Search "%{query}" in all guide pages
     sub_heading_html: Wayfinders for our collections, tools, and services
+    toggle_button_text: Show %{total} guides
   library_website_search:
     display_name: "Library website"
     short_display_name: "Website"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,7 +19,8 @@ LIBGUIDES:
   API_URL: 'https://example.com/1.1/guides'
   SITE_ID: 123456
   KEY: abc1234
-  QUERY_URL: 'TODO'
+  NUM_RESULTS_SHOWN: 5
+  QUERY_URL: 'https://guides.library.stanford.edu/srch.php?q=%{q}'
   HOME_URL: 'https://guides.library.stanford.edu/'
 
 EXHIBITS:

--- a/spec/searchers/quick_search/lib_guides_searcher_spec.rb
+++ b/spec/searchers/quick_search/lib_guides_searcher_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe QuickSearch::LibGuidesSearcher do
 
   it { expect(searcher).to be_an(QuickSearch::Searcher) }
   it { expect(searcher.search).to be_an(LibGuidesSearchService::Response) }
+  it { expect(searcher).to be_toggleable }
+  it { expect(searcher.toggle_threshold).to be 5 }
   it do
     searcher.search # loads response
     expect(searcher.results).to be_an(Array)


### PR DESCRIPTION
Closes #314 
Closes #316 

## Before
<img width="568" alt="guides-before" src="https://user-images.githubusercontent.com/96776/89572914-aa69e680-d7de-11ea-9bb7-1a667c4723b2.png">

## After
<img width="571" alt="guides-after" src="https://user-images.githubusercontent.com/96776/89572923-accc4080-d7de-11ea-8748-b55029a1ba20.png">
