### PR TITLE
Apply new config patterns to catalog and articles

### DIFF
--- a/app/searchers/quick_search/article_searcher.rb
+++ b/app/searchers/quick_search/article_searcher.rb
@@ -9,7 +9,7 @@ module QuickSearch
     end
 
     def loaded_link
-      format(Settings.EDS_QUERY_URL.to_s, q: CGI.escape(q.to_s))
+      format(Settings.ARTICLE.QUERY_URL.to_s, q: CGI.escape(q.to_s))
     end
   end
 end

--- a/app/searchers/quick_search/catalog_searcher.rb
+++ b/app/searchers/quick_search/catalog_searcher.rb
@@ -9,7 +9,7 @@ module QuickSearch
     end
 
     def loaded_link
-      format(Settings.CATALOG_QUERY_URL.to_s, q: CGI.escape(q.to_s))
+      format(Settings.CATALOG.QUERY_URL.to_s, q: CGI.escape(q.to_s))
     end
   end
 end

--- a/app/services/article_search_service.rb
+++ b/app/services/article_search_service.rb
@@ -3,14 +3,14 @@
 # Uses the Blacklight JSON API to search and then extracts select EDS fields
 class ArticleSearchService < AbstractSearchService
   def initialize(options = {})
-    options[:query_url] ||= Settings.EDS_QUERY_API_URL.to_s
+    options[:query_url] ||= Settings.ARTICLE.API_URL.to_s
     options[:response_class] ||= Response
     super
   end
 
   class Response < AbstractSearchService::Response
     HIGHLIGHTED_FACET_FIELD = 'eds_publication_type_facet'
-    QUERY_URL = Settings.EDS_QUERY_URL
+    QUERY_URL = Settings.ARTICLE.QUERY_URL
 
     def total
       json['response']['pages']['total_count'].to_i
@@ -21,7 +21,7 @@ class ArticleSearchService < AbstractSearchService
       solr_docs.collect do |doc|
         result = AbstractSearchService::Result.new
         result.title = doc['eds_title']
-        result.link = format(Settings.EDS_FETCH_URL.to_s, id: doc['id'])
+        result.link = format(Settings.ARTICLE.FETCH_URL.to_s, id: doc['id'])
         result.id = doc['id']
         result.fulltext_link_html = doc['fulltext_link_html']
         result.author = doc['eds_authors']&.first

--- a/app/services/catalog_search_service.rb
+++ b/app/services/catalog_search_service.rb
@@ -3,14 +3,14 @@
 # Uses the Blacklight JSON API to search and then extracts select Catalog fields
 class CatalogSearchService < AbstractSearchService
   def initialize(options = {})
-    options[:query_url] ||= Settings.CATALOG_QUERY_API_URL.to_s
+    options[:query_url] ||= Settings.CATALOG.API_URL.to_s
     options[:response_class] ||= Response
     super
   end
 
   class Response < AbstractSearchService::Response
     HIGHLIGHTED_FACET_FIELD = 'format_main_ssim'
-    QUERY_URL = Settings.CATALOG_QUERY_URL
+    QUERY_URL = Settings.CATALOG.QUERY_URL
     ADDITIONAL_FACET_TARGET = 'Database'
 
     def total
@@ -22,7 +22,7 @@ class CatalogSearchService < AbstractSearchService
       solr_docs.collect do |doc|
         result = AbstractSearchService::Result.new
         result.title = doc['title_display'] || doc['title_full_display']
-        result.link = format(Settings.CATALOG_FETCH_URL.to_s, id: doc['id'])
+        result.link = format(Settings.CATALOG.FETCH_URL.to_s, id: doc['id'])
         result.author = doc['author_person_display']&.first
         result.imprint = doc['imprint_display']&.first
         result.fulltext_link_html = doc['fulltext_link_html']&.first

--- a/app/views/quick_search/pages/home.html.erb
+++ b/app/views/quick_search/pages/home.html.erb
@@ -5,20 +5,25 @@
 </div>
 
 <div class='card-deck bento-panels homepage-panels'>
-  <div class='card'>
-    <%= image_tag 'catalog.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
-    <div class='card-body'>
-      <h2 class='card-title'><%= link_to 'Catalog', Settings.CATALOG_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('catalog_search.sub_heading_html') %></p>
+  <% if Settings.ENABLED_SEARCHERS.include?('catalog') %>
+    <div class='card'>
+      <%= image_tag 'catalog.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
+      <div class='card-body'>
+        <h2 class='card-title'><%= link_to 'Catalog', Settings.CATALOG.HOME_URL %></h2>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('catalog_search.sub_heading_html') %></p>
+      </div>
     </div>
-  </div>
-  <div class='card'>
-    <%= image_tag 'articles.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
-    <div class='card-body'>
-      <h2 class='card-title'><%= link_to 'Articles+', Settings.ARTICLES_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('article_search.sub_heading_html') %></p>
+  <% end %>
+
+  <% if Settings.ENABLED_SEARCHERS.include?('article') %>
+    <div class='card'>
+      <%= image_tag 'articles.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
+      <div class='card-body'>
+        <h2 class='card-title'><%= link_to 'Articles+', Settings.ARTICLE.HOME_URL %></h2>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('article_search.sub_heading_html') %></p>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <% if Settings.ENABLED_SEARCHERS.include?('lib_guides') %>
     <div class='card'>

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -9,41 +9,25 @@
 <div class="quicksearch-ga-click-tracking">
   <div class="row articles-catalog">
     <div class="col-md-6 module">
-      <div id="catalog" class="module-contents" tabindex="-1">
-        <p class="search-error" data-quicksearch-search-endpoint="catalog"
-                                data-quicksearch-page=""
-                                data-quicksearch-template=""></p>
-      </div>
+      <% if Settings.ENABLED_SEARCHERS.include?('catalog') %>
+        <div id="catalog" class="module-contents" tabindex="-1">
+          <p class="search-error" data-quicksearch-search-endpoint="catalog"
+                                  data-quicksearch-page=""
+                                  data-quicksearch-template=""></p>
+        </div>
+      <% end %>
     </div>
     <div class="col-md-6 module">
-      <div id="article" class="module-contents" tabindex="-1">
-        <p class="search-error" data-quicksearch-search-endpoint="article"
-                                data-quicksearch-page=""
-                                data-quicksearch-template=""></p>
-      </div>
+      <% if Settings.ENABLED_SEARCHERS.include?('article') %>
+        <div id="article" class="module-contents" tabindex="-1">
+          <p class="search-error" data-quicksearch-search-endpoint="article"
+                                  data-quicksearch-page=""
+                                  data-quicksearch-template=""></p>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>
-
-<div class="quicksearch-ga-click-tracking">
-  <div class="row">
-    <div class="col-md-6 library-website module">
-      <div id="library-website" class="module-contents" tabindex="-1">
-        <p class="search-error" data-quicksearch-search-endpoint="library_website"
-                                data-quicksearch-page=""
-                                data-quicksearch-template=""></p>
-      </div>
-    </div>
-    <div class="col-md-6 yewno module">
-      <div id="yewno" class="module-contents" tabindex="-1">
-        <h2 class="result-set-heading">Yewno</h2>
-        <span class="h3 result-set-subheading"><%= t('yewno.sub_heading_html') %></span>
-        <div id="yewno-results"></div>
-      </div>
-    </div>
-  </div>
-</div>
-
 
 <div class="quicksearch-ga-click-tracking">
   <div class="row">
@@ -56,7 +40,19 @@
         </div>
       </div>
     <% end %>
+    <div class="col-md-6 library-website module">
+      <div id="library-website" class="module-contents" tabindex="-1">
+        <p class="search-error" data-quicksearch-search-endpoint="library_website"
+                                data-quicksearch-page=""
+                                data-quicksearch-template=""></p>
+      </div>
+    </div>
+  </div>
+</div>
 
+
+<div class="quicksearch-ga-click-tracking">
+  <div class="row">
     <% if Settings.ENABLED_SEARCHERS.include?('exhibits') %>
       <div class="col-md-6 exhibits module">
         <div id="exhibits" class="module-contents" >
@@ -66,6 +62,14 @@
         </div>
       </div>
     <% end %>
+
+    <div class="col-md-6 yewno module">
+      <div id="yewno" class="module-contents" tabindex="-1">
+        <h2 class="result-set-heading">Yewno</h2>
+        <span class="h3 result-set-subheading"><%= t('yewno.sub_heading_html') %></span>
+        <div id="yewno-results"></div>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,7 +24,7 @@ LIBGUIDES:
   KEY: abc1234
   NUM_RESULTS_SHOWN: 3
   QUERY_URL: 'https://guides.library.stanford.edu/srch.php?q=%{q}'
-  HOME_URL: 'https://guides.library.stanford.edu/'
+  HOME_URL: 'https://guides.library.stanford.edu'
 EXHIBITS:
   API_URL: 'https://exhibits.stanford.edu/exhibit_finder?q=%{q}'
   HOME_URL: 'https://exhibits.stanford.edu'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,16 @@ ENABLED_SEARCHERS:
   - catalog
   - article
   - library_website
+CATALOG:
+  API_URL: 'https://searchworks.stanford.edu/?q=%{q}&rows=%{max}&format=json'
+  QUERY_URL: 'https://searchworks.stanford.edu/?q=%{q}'
+  FETCH_URL: 'https://searchworks.stanford.edu/view/%{id}'
+  HOME_URL: 'https://searchworks.stanford.edu'
+ARTICLE:
+  API_URL: 'https://searchworks.stanford.edu/articles?q=%{q}&rows=%{max}&format=json'
+  QUERY_URL: 'https://searchworks.stanford.edu/articles?q=%{q}'
+  FETCH_URL: 'https://searchworks.stanford.edu/articles/%{id}'
+  HOME_URL: 'https://searchworks.stanford.edu/articles'
 LIBGUIDES:
   API_URL: 'https://example.com/1.1/guides'
   SITE_ID: 123456
@@ -21,13 +31,3 @@ EXHIBITS:
   LINK_URL: 'https://exhibits.stanford.edu/%{id}'
   NUM_RESULTS_SHOWN: 3
   QUERY_URL: 'https://exhibits.stanford.edu/search?q=%{q}'
-CATALOG:
-  API_URL: 'https://searchworks.stanford.edu/?q=%{q}&rows=%{max}&format=json'
-  QUERY_URL: 'https://searchworks.stanford.edu/?q=%{q}'
-  FETCH_URL: 'https://searchworks.stanford.edu/view/%{id}'
-  HOME_URL: 'https://searchworks.stanford.edu'
-ARTICLE:
-  API_URL: 'https://searchworks.stanford.edu/articles?q=%{q}&rows=%{max}&format=json'
-  QUERY_URL: 'https://searchworks.stanford.edu/articles?q=%{q}'
-  FETCH_URL: 'https://searchworks.stanford.edu/articles/%{id}'
-  HOME_URL: 'https://searchworks.stanford.edu/articles'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,13 +1,6 @@
-EDS_QUERY_API_URL: 'https://searchworks.stanford.edu/articles?q=%{q}&rows=%{max}&format=json'
-EDS_QUERY_URL: 'https://searchworks.stanford.edu/articles?q=%{q}'
-EDS_FETCH_URL: 'https://searchworks.stanford.edu/articles/%{id}'
-CATALOG_QUERY_API_URL: 'https://searchworks.stanford.edu/?q=%{q}&rows=%{max}&format=json'
-CATALOG_QUERY_URL: 'https://searchworks.stanford.edu/?q=%{q}'
-CATALOG_FETCH_URL: 'https://searchworks.stanford.edu/view/%{id}'
 LIBRARY_WEBSITE_QUERY_API_URL: 'https://library.stanford.edu/search/website?search=%{q}'
 MAX_RESULTS: 3
-CATALOG_HOME_URL: 'https://searchworks.stanford.edu'
-ARTICLES_HOME_URL: 'https://searchworks.stanford.edu/articles'
+
 LIBRARY_WEBSITE_HOME_URL: 'https://library.stanford.edu'
 YEWNO_HOME_URL: 'https://stanford.idm.oclc.org/login?url=https://discover.yewno.com'
 GLOBAL_ALERT: <%= false %>
@@ -28,3 +21,13 @@ EXHIBITS:
   LINK_URL: 'https://exhibits.stanford.edu/%{id}'
   NUM_RESULTS_SHOWN: 3
   QUERY_URL: 'https://exhibits.stanford.edu/search?q=%{q}'
+CATALOG:
+  API_URL: 'https://searchworks.stanford.edu/?q=%{q}&rows=%{max}&format=json'
+  QUERY_URL: 'https://searchworks.stanford.edu/?q=%{q}'
+  FETCH_URL: 'https://searchworks.stanford.edu/view/%{id}'
+  HOME_URL: 'https://searchworks.stanford.edu'
+ARTICLE:
+  API_URL: 'https://searchworks.stanford.edu/articles?q=%{q}&rows=%{max}&format=json'
+  QUERY_URL: 'https://searchworks.stanford.edu/articles?q=%{q}'
+  FETCH_URL: 'https://searchworks.stanford.edu/articles/%{id}'
+  HOME_URL: 'https://searchworks.stanford.edu/articles'

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -18,8 +18,16 @@ feature 'Homepage' do
         text: 'Articles+'
       )
       expect(page).to have_css(
+        'a[href="https://guides.library.stanford.edu"]',
+        text: 'Guides'
+      )
+      expect(page).to have_css(
         'a[href="https://library.stanford.edu"]',
         text: 'Library website'
+      )
+      expect(page).to have_css(
+        'a[href="https://exhibits.stanford.edu"]',
+        text: 'Exhibits'
       )
       expect(page).to have_css(
         'a[href="https://stanford.idm.oclc.org/login?url=https://discover.yewno.com"]', # rubocop:disable LineLength


### PR DESCRIPTION
Closes #338
Closes #327 

This PR:
- moves around catalog and article settings so they're nice n' readable like exhibits API and libweb API
- Adds the `ENBALED_SEARCHERS` pattern to catalog and articles

