### PR TITLE
Update searcher description text

### DIFF
--- a/app/views/quick_search/pages/home.html.erb
+++ b/app/views/quick_search/pages/home.html.erb
@@ -9,14 +9,14 @@
     <%= image_tag 'catalog.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
     <div class='card-body'>
       <h2 class='card-title'><%= link_to 'Catalog', Settings.CATALOG_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Physical and digital books, media, journals, archives, and databases.</p>
+      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('catalog_search.sub_heading_html') %></p>
     </div>
   </div>
   <div class='card'>
     <%= image_tag 'articles.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
     <div class='card-body'>
       <h2 class='card-title'><%= link_to 'Articles+', Settings.ARTICLES_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Journal articles, e-books, and other e-resources.</p>
+      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('article_search.sub_heading_html') %></p>
     </div>
   </div>
 
@@ -25,7 +25,7 @@
       <%= image_tag 'guides.png', class: 'card-img-top', alt: '', role: 'presentation' %>
       <div class='card-body'>
         <h2 class='card-title'><%= link_to 'Guides', Settings.LIBGUIDES.HOME_URL %></h2>
-        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Course- and topic-based guides to collections, tools, and services.</p>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('lib_guides_search.sub_heading_html') %></p>
       </div>
     </div>
   <% end %>
@@ -34,7 +34,7 @@
     <%= image_tag 'website.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
     <div class='card-body'>
       <h2 class='card-title'><%= link_to 'Library website', Settings.LIBRARY_WEBSITE_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Libraries and subject specialists; blogs, events, and policies.</p>
+      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('library_website_search.sub_heading_html') %></p>
     </div>
   </div>
 
@@ -43,7 +43,7 @@
       <%= image_tag 'exhibits.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
       <div class='card-body'>
         <h2 class='card-title'><%= link_to 'Exhibits', Settings.EXHIBITS.HOME_URL %></h2>
-        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Digital showcases for research and teaching.</p>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('exhibits_search.sub_heading_html') %></p>
       </div>
     </div>
   <% end %>
@@ -52,7 +52,7 @@
     <%= image_tag 'yewno.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
     <div class='card-body'>
       <h2 class='card-title'><%= link_to 'Yewno', Settings.YEWNO_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Knowledge graphs for interconnecting concepts.</p>
+      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'><%= t('yewno.sub_heading_html') %></p>
     </div>
   </div>
 </div>

--- a/app/views/quick_search/pages/home.html.erb
+++ b/app/views/quick_search/pages/home.html.erb
@@ -1,7 +1,7 @@
 <% title %>
 
 <div class='h2 row mb-4 subtitle'>
-  Look in all these sources with one search
+  "Search all" covers these sources
 </div>
 
 <div class='card-deck bento-panels homepage-panels'>
@@ -9,14 +9,14 @@
     <%= image_tag 'catalog.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
     <div class='card-body'>
       <h2 class='card-title'><%= link_to 'Catalog', Settings.CATALOG_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Search the physical collections and digital resources of Stanford’s libraries. Find books, media, and <a href="https://searchworks.stanford.edu/databases">topic-specific databases</a>.</p>
+      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Physical and digital books, media, journals, archives, and databases.</p>
     </div>
   </div>
   <div class='card'>
     <%= image_tag 'articles.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
     <div class='card-body'>
       <h2 class='card-title'><%= link_to 'Articles+', Settings.ARTICLES_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Search a combined index of 100s of databases, and connect directly to the article or resource.</p>
+      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Journal articles, e-books, and other e-resources.</p>
     </div>
   </div>
 
@@ -25,7 +25,7 @@
       <%= image_tag 'guides.png', class: 'card-img-top', alt: '', role: 'presentation' %>
       <div class='card-body'>
         <h2 class='card-title'><%= link_to 'Guides', Settings.LIBGUIDES.HOME_URL %></h2>
-        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Wayfinders for our collections, tools, and services.</p>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Course- and topic-based guides to collections, tools, and services.</p>
       </div>
     </div>
   <% end %>
@@ -34,7 +34,7 @@
     <%= image_tag 'website.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
     <div class='card-body'>
       <h2 class='card-title'><%= link_to 'Library website', Settings.LIBRARY_WEBSITE_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Find topic specialists, blog posts, descriptions of our notable collections, as well as libraries, hours, and policies.</p>
+      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Libraries and subject specialists; blogs, events, and policies.</p>
     </div>
   </div>
 
@@ -43,7 +43,7 @@
       <%= image_tag 'exhibits.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
       <div class='card-body'>
         <h2 class='card-title'><%= link_to 'Exhibits', Settings.EXHIBITS.HOME_URL %></h2>
-        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Find digital showcases for research and teaching in Spotlight at Stanford.</p>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Digital showcases for research and teaching.</p>
       </div>
     </div>
   <% end %>
@@ -52,7 +52,7 @@
     <%= image_tag 'yewno.jpg', class: 'card-img-top', alt: '', role: 'presentation' %>
     <div class='card-body'>
       <h2 class='card-title'><%= link_to 'Yewno', Settings.YEWNO_HOME_URL %></h2>
-      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Explore concepts and connections, and understand interdisciplinary subjects, in a graph interface.</p>
+      <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Knowledge graphs for interconnecting concepts.</p>
     </div>
   </div>
 </div>

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -37,7 +37,7 @@
     <div class="col-md-6 yewno module">
       <div id="yewno" class="module-contents" tabindex="-1">
         <h2 class="result-set-heading">Yewno</h2>
-        <span class="h3 result-set-subheading">Knowledge graphs for interconnecting concepts.</span>
+        <span class="h3 result-set-subheading"><%= t('yewno.sub_heading_html') %></span>
         <div id="yewno-results"></div>
       </div>
     </div>

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -37,7 +37,7 @@
     <div class="col-md-6 yewno module">
       <div id="yewno" class="module-contents" tabindex="-1">
         <h2 class="result-set-heading">Yewno</h2>
-        <span class="h3 result-set-subheading">Explore relationships among concepts</span>
+        <span class="h3 result-set-subheading">Knowledge graphs for interconnecting concepts.</span>
         <div id="yewno-results"></div>
       </div>
     </div>

--- a/app/views/shared/_more_search_tools.html.erb
+++ b/app/views/shared/_more_search_tools.html.erb
@@ -4,7 +4,7 @@
       <%= image_tag 'search.svg', class: 'media-object card-img-left', alt: '', 'aria-hidden': true %>
       <div class='card-body'>
         <h2 class='card-title'><%= link_to 'More search tools', 'https://library.stanford.edu/search-services' %></h2>
-        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Discover and access library and archival materials, journals, databases, data, and e-resources beyond SearchWorks.</p>
+        <p class='card-text d-none d-sm-block d-md-block d-lg-block d-xl-block'>Tools to help you discover resources at Stanford and beyond.</p>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,5 +54,7 @@ en:
     error_service_mesasge: "searching library website"
     no_results_service_message: "a different search"
     no_results_link: "http://library.stanford.edu/search/website"
+  yewno:
+    sub_heading_html: Knowledge graphs for interconnecting concepts.
   search_form:
     placeholder: "catalog + articles + website + more"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
     micro_display_name: exhibits
     no_results_service_message: "a different search"
     pass_on_search_link_text: Search "%{query}" in all exhibit items
-    sub_heading_html: Digital showcase for research and teaching
+    sub_heading_html: Digital showcases for research and teaching.
     toggle_button_text: Show %{total} exhibits
   global_alert_html: >
     <b>RESEARCH RESTART</b><br/>
@@ -19,7 +19,7 @@ en:
   catalog_search:
     display_name: "Catalog"
     short_display_name: "Catalog"
-    sub_heading_html: Books, media, physical & digital resources
+    sub_heading_html: Physical and digital books, media, journals, archives, and databases.
     micro_display_name: "catalog"
     search_form_placeholder: "Search SearchWorks catalog"
     module_callout: "Search SearchWorks catalog"
@@ -29,7 +29,7 @@ en:
   article_search:
     display_name: "Articles+"
     short_display_name: "Articles+"
-    sub_heading_html: Journal articles, e-books, & other e-resources
+    sub_heading_html: Journal articles, e-books, and other e-resources.
     micro_display_name: "articles+"
     search_form_placeholder: "Search SearchWorks articles+"
     module_callout: "Search SearchWorks articles+"
@@ -42,12 +42,12 @@ en:
     micro_display_name: guide
     no_results_service_message: "a different search"
     pass_on_search_link_text: Search "%{query}" in all guide pages
-    sub_heading_html: Wayfinders for our collections, tools, and services
+    sub_heading_html: Course- and topic-based guides to collections, tools, and services.
     toggle_button_text: Show %{total} guides
   library_website_search:
     display_name: "Library website"
     short_display_name: "Website"
-    sub_heading_html: "Library info; guides & content by subject specialists"
+    sub_heading_html: "Libraries and subject specialists; blogs, events, and policies."
     micro_display_name: "website"
     search_form_placeholder: "Search Library website"
     module_callout: "Search Library website"

--- a/spec/views/quick_search/search/_module_heading.html.erb_spec.rb
+++ b/spec/views/quick_search/search/_module_heading.html.erb_spec.rb
@@ -18,6 +18,6 @@ describe 'quick_search/search/_module_heading.html.erb' do
 
   it 'renders if there are no results' do
     expect(rendered).to have_css('.result-set-heading', text: 'Catalog')
-    expect(rendered).to have_css('.result-set-subheading', text: /Books/)
+    expect(rendered).to have_css('.result-set-subheading', text: /Physical and digital/)
   end
 end


### PR DESCRIPTION
Closes #342
- Updates searcher descriptions per feedback from OEG.
- consolidates some of these strings into existing i18n keys

🤞 This should clear the way for some refactoring of this view!

## Before
![old homepage text](https://user-images.githubusercontent.com/5402927/89598703-4fea7d80-d812-11ea-9b70-485649c730da.png)

## After
!homepage with new text](https://user-images.githubusercontent.com/5402927/89598711-52e56e00-d812-11ea-95b2-d698243425c7.png)
