### PR TITLE
Update result styling

### DIFF
--- a/app/assets/stylesheets/modules/results.scss
+++ b/app/assets/stylesheets/modules/results.scss
@@ -1,10 +1,23 @@
 .result-title {
   font-size: 1.215em;
-  padding-top: 10px;
 }
 
 .module-contents {
-  ol { padding-left: 18px; }
+  ol {
+    padding-left: 18px;
+
+    .no-thumbnail {
+      border-bottom: 1px solid $su-cloud;
+      margin-bottom: 15px;
+      padding-bottom: 5px;
+    }
+
+    .with-thumbnail {
+      border-bottom: 1px solid $su-cloud;
+      margin-bottom: 15px;
+      padding-bottom: 0;
+    }
+  }
 }
 
 .result-set-subheading {

--- a/app/assets/stylesheets/modules/results.scss
+++ b/app/assets/stylesheets/modules/results.scss
@@ -20,6 +20,12 @@
   }
 }
 
+.exhibits.module {
+  ol {
+    list-style-type: none;
+  }
+}
+
 .result-set-subheading {
   display: block;
   font-size: $font-size-base;

--- a/app/views/quick_search/search/_result_with_thumbnail.html.erb
+++ b/app/views/quick_search/search/_result_with_thumbnail.html.erb
@@ -17,7 +17,7 @@
           <% end %>
       </div>
   <% end %>
-  <div class="col-sm-9 columns">
+  <div class="col-sm-9 pl-0 columns">
       <%= render partial: '/quick_search/search/result_details', locals: { result: result } %>
   </div>
 </div>


### PR DESCRIPTION
Closes #347 
Closes #349 

## Exhibits (before)
<img width="567" alt="exhibits-bento-before" src="https://user-images.githubusercontent.com/96776/89832831-c938e780-db14-11ea-9940-1d81e1afeed7.png">

## Exhibits (after)
<img width="574" alt="exhibits-bento-after" src="https://user-images.githubusercontent.com/96776/89838005-f68a9300-db1e-11ea-8d84-2f33a1b25a09.png">

## Articles+ (before)
<img width="561" alt="article-bento-before" src="https://user-images.githubusercontent.com/96776/89832840-cdfd9b80-db14-11ea-903f-c684bcce2a68.png">

## Articles+ (after)
<img width="563" alt="article-bento-after" src="https://user-images.githubusercontent.com/96776/89832846-ce963200-db14-11ea-9a75-7d45798e8109.png">
