### PR TITLE
Remove temporary fix for BOM character in libweb API

### DIFF
--- a/app/services/library_website_api_search_service.rb
+++ b/app/services/library_website_api_search_service.rb
@@ -50,11 +50,8 @@ class LibraryWebsiteApiSearchService < AbstractSearchService
     private
 
     def json
-      # Force UTF-8 as the API returns BOM
-      @json ||= JSON.parse(
-        @body.gsub("\xEF\xBB\xBF".dup.force_encoding(Encoding::BINARY), '')
-      )
+      @json ||= JSON.parse(@body)
     end
-    
+
   end
 end


### PR DESCRIPTION
This workaround is no longer necessary because of fixes in the upstream libweb API.
https://github.com/sul-dlss/sul-bento-app/issues/105#issuecomment-671432904