### PR TITLE
Add breadcrumbs to libweb search results

### DIFF
--- a/app/assets/stylesheets/modules/libweb.scss
+++ b/app/assets/stylesheets/modules/libweb.scss
@@ -1,11 +1,9 @@
 .library-website.module {
   .libweb-breadcrumb {
-    ol {
-      list-style: none;
-      margin-left: 0;
-      margin-right: 0;
-      padding-left: 0;
-    }
+    list-style: none;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 0;
 
     li {
       display: inline;

--- a/app/assets/stylesheets/modules/libweb.scss
+++ b/app/assets/stylesheets/modules/libweb.scss
@@ -1,0 +1,14 @@
+.library-website.module {
+  .libweb-breadcrumb {
+    ol {
+      list-style: none;
+      margin-left: 0;
+      margin-right: 0;
+      padding-left: 0;
+    }
+
+    li {
+      display: inline;
+    }
+  }
+}

--- a/app/assets/stylesheets/sul-bento.scss
+++ b/app/assets/stylesheets/sul-bento.scss
@@ -13,6 +13,7 @@
 @import 'modules/stanford-only';
 @import 'modules/highlighted_facet';
 @import 'modules/online-label';
+@import 'modules/libweb';
 @import 'modules/yewno';
 @import 'modules/searcher-anchors';
 @import 'modules/skip-links';

--- a/app/services/library_website_api_search_service.rb
+++ b/app/services/library_website_api_search_service.rb
@@ -26,6 +26,7 @@ class LibraryWebsiteApiSearchService < AbstractSearchService
         result.title = doc['title']
         result.link = doc['url']
         result.description = sanitizer.sanitize(doc['description'])
+        result.breadcrumbs = doc['breadcrumbs']
         result
       end
     end

--- a/app/views/quick_search/search/_result_details.html.erb
+++ b/app/views/quick_search/search/_result_details.html.erb
@@ -30,14 +30,12 @@
 <% end %>
 
 <% if result.breadcrumbs.present? %>
-  <nav aria-label="breadcrumb" class="libweb-breadcrumb">
-    <ol>
-      <% result.breadcrumbs.each do |breadcrumb| %>
-        <li>
-          <span aria-hidden="true">&raquo;</span>
-          <%= link_to breadcrumb["label"], breadcrumb["url"] %>
-        </li>
-      <% end %>
-    </ol>
-  </nav>
+  <ol aria-label="breadcrumb" class="libweb-breadcrumb">
+    <% result.breadcrumbs.each do |breadcrumb| %>
+      <li>
+        <span aria-hidden="true">&raquo;</span>
+        <%= link_to breadcrumb["label"], breadcrumb["url"] %>
+      </li>
+    <% end %>
+  </ol>
 <% end %>

--- a/app/views/quick_search/search/_result_details.html.erb
+++ b/app/views/quick_search/search/_result_details.html.erb
@@ -28,3 +28,16 @@
 <% if result.fulltext_link_html %>
   <p><%= result.fulltext_link_html.html_safe %></p>
 <% end %>
+
+<% if result.breadcrumbs.present? %>
+  <nav aria-label="breadcrumb" class="libweb-breadcrumb">
+    <ol>
+      <% result.breadcrumbs.each do |breadcrumb| %>
+        <li>
+          <span aria-hidden="true">&raquo;</span>
+          <%= link_to breadcrumb["label"], breadcrumb["url"] %>
+        </li>
+      <% end %>
+    </ol>
+  </nav>
+<% end %>

--- a/spec/services/library_website_api_search_service_spec.rb
+++ b/spec/services/library_website_api_search_service_spec.rb
@@ -11,7 +11,17 @@ RSpec.describe LibraryWebsiteApiSearchService do
         {
           title: 'Chinese art: Traditional',
           url: 'https://library.stanford.edu/guides/chinese-art-traditional',
-          description: 'This guide...'
+          description: 'This guide...',
+          breadcrumbs: [
+            {
+              "label": "Home",
+              "url": "https://library.stanford.edu/"
+            },
+            {
+              "label": "Guides",
+              "url": "https://library.stanford.edu/guides"
+            }
+          ]
         }
       ],
       facets: {
@@ -53,6 +63,12 @@ RSpec.describe LibraryWebsiteApiSearchService do
       results = service.search(query).results
       expect(results.length).to eq 1
       expect(results.first.title).to eq 'Chinese art: Traditional'
+    end
+
+    it 'provides libweb breadcrumbs' do
+      results = service.search(query).results
+      expect(results.first.breadcrumbs.length).to eq 2
+      expect(results.first.breadcrumbs.last["label"]).to eq 'Guides'
     end
   end
 end


### PR DESCRIPTION
Closes #51, see designs in #15

This PR uses the shiny new libweb API to adds breadcrumbs to each Library website result.

## Screenshots
### Before
![results-before](https://user-images.githubusercontent.com/5402927/91508679-0a5b2680-e88d-11ea-91b4-ab197514d9d0.png)

### After
![results-with-breadcrumbs-added](https://user-images.githubusercontent.com/5402927/91508680-0b8c5380-e88d-11ea-9e8e-f079f6107da0.png)


## Accessibility notes
I think this is ok for a first implementation, but when we have some time again it's worth circling back for accessibility review of this particular component (ticketed: #379)

- [w3: breadcrumb pattern](https://www.w3.org/TR/wai-aria-practices-1.1/examples/breadcrumb/index.html)
	- decorative elements added via markup but hidden from screenreader with `aria-hidden`
		- I tried using a CSS `::after`. In VoiceOver it didn't announce the &raquo;, but it made the `<ol>` twice as long?? (1 of 8 links!)
	- I decided not to use the recommended `<nav>` tag here 
		- the w3 pattern breadcrumb assumes that the breadcrumb is for the current page and that there's only 1 per page
		- The `<nav>` tag makes these breadcrumbs REALLY jump out in the Landmarks list in a way that seems to elevate it above equivalent search results.![page landmarks with result breadcrumbs](https://user-images.githubusercontent.com/5402927/91510553-480e7e00-e892-11ea-9ac3-ff085b3068ee.png)
		- I added an aria label to the `<ol>`. We'll probably come up with a better text label after pairing with JV.


