### PR TITLE
Remove 'Home' from breadcrumbs to reduce noise

### DIFF
--- a/app/services/library_website_api_search_service.rb
+++ b/app/services/library_website_api_search_service.rb
@@ -26,7 +26,7 @@ class LibraryWebsiteApiSearchService < AbstractSearchService
         result.title = doc['title']
         result.link = doc['url']
         result.description = sanitizer.sanitize(doc['description'])
-        result.breadcrumbs = doc['breadcrumbs']
+        result.breadcrumbs = doc['breadcrumbs']&.drop(1)
         result
       end
     end

--- a/spec/services/library_website_api_search_service_spec.rb
+++ b/spec/services/library_website_api_search_service_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe LibraryWebsiteApiSearchService do
 
     it 'provides libweb breadcrumbs' do
       results = service.search(query).results
-      expect(results.first.breadcrumbs.length).to eq 2
-      expect(results.first.breadcrumbs.last["label"]).to eq 'Guides'
+      expect(results.first.breadcrumbs.length).to eq 1
+      expect(results.first.breadcrumbs.first["label"]).to eq 'Guides'
     end
   end
 end


### PR DESCRIPTION
Fixes #379

## Before 
![Sample breadcrumb: Home, About, News](https://user-images.githubusercontent.com/5402927/91677744-8016fa80-eaf8-11ea-901a-3c41f2b7244b.png)

## After
![Shortened breadcrumb: About, News](https://user-images.githubusercontent.com/5402927/91677747-81482780-eaf8-11ea-84ac-8a72284bf1ea.png)