### PR TITLE
Update Library services menu

### DIFF
--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -2,8 +2,12 @@
   background-color: $sul-subnavbar-bg-color;
   box-shadow: 0 4px 8px -2px rgba(0, 0, 0, 0.2);
   color: $white;
-  min-height: 35px;
   margin-bottom: 1.5rem;
+  min-height: 35px;
+
+  .dropdown-toggle {
+    padding: 0;
+  }
 
   .dropdown-toggle, .nav-item {
     color: $white;
@@ -12,23 +16,16 @@
   }
 
   .dropdown-toggle:after, .nav-item:after {
-    margin-left:0px;
-    border-top-width:4px;
-    border-right-width:4px;
-    border-left-width:4px;
-  }
-
-  .navbar-toggle {
-    font-size: 20px;
-    margin: 0;
-    padding: 0;
+    border-left-width: 4px;
+    border-right-width: 4px;
+    border-top-width: 4px;
+    margin-left: 0;
   }
 
   .covid-status {
     background-color: $su-poppy;
     color: $black;
-    padding-left: 15px;
-    padding-right: 15px;
+    padding: 0 15px 2px;
   }
 
   .sul-services-menu {
@@ -58,6 +55,7 @@
     border-radius: 0;
     left: inherit;
 
+    // Menu subheadings
     .menugroup {
       font-variant: all-small-caps;
     }

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -5,13 +5,13 @@
   min-height: 35px;
   margin-bottom: 1.5rem;
 
-  .dropdown-toggle {
+  .dropdown-toggle, .nav-item {
     color: $white;
     font-size: 22px;
     font-weight: 100;
   }
 
-  .dropdown-toggle:after {
+  .dropdown-toggle:after, .nav-item:after {
     margin-left:0px;
     border-top-width:4px;
     border-right-width:4px;
@@ -22,6 +22,13 @@
     font-size: 20px;
     margin: 0;
     padding: 0;
+  }
+
+  .covid-status {
+    background-color: $su-poppy;
+    color: $black;
+    padding-left: 15px;
+    padding-right: 15px;
   }
 
   .sul-services-menu {
@@ -66,13 +73,6 @@
     li.text-muted, li.dropdown-header, li span {
       color: $white;
       padding-left: 15px;
-    }
-
-    .divider {
-      background-color: transparent;
-      border-bottom: $white dotted 1px;
-      margin-left: 15px;
-      margin-right: 15px;
     }
   }
 }

--- a/app/assets/stylesheets/modules/subnavbar.scss
+++ b/app/assets/stylesheets/modules/subnavbar.scss
@@ -51,7 +51,11 @@
     border-radius: 0;
     left: inherit;
 
-    li a {
+    .menugroup {
+      font-variant: all-small-caps;
+    }
+
+    li a, li span {
       font-size: 16px;
       font-weight: 100;
       line-height: 35px;
@@ -59,7 +63,7 @@
       padding: 0 24px;
     }
 
-    li.text-muted, li.dropdown-header {
+    li.text-muted, li.dropdown-header, li span {
       color: $white;
       padding-left: 15px;
     }

--- a/app/views/shared/_services_menu.html.erb
+++ b/app/views/shared/_services_menu.html.erb
@@ -1,4 +1,4 @@
-<ul class="dropdown-menu sul-services-menu" role="menu">
+<ul class="dropdown-menu sul-services-menu" role="menu" aria-labelledby="services">
   <li>
     <span class="menugroup">Need help?</span>
     <ul>

--- a/app/views/shared/_services_menu.html.erb
+++ b/app/views/shared/_services_menu.html.erb
@@ -3,10 +3,13 @@
     <span class="menugroup">Need help?</span>
     <ul>
       <li>
-        <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">Connecting to e-resources</a>
+        <a role="menuitem" href="https://library.stanford.edu/chat" class="stanford-only" title="limited to Stanford community">Chat with us  <span class="sr-only"> (limited to Stanford community)</span></a>
       </li>
       <li>
-        <a role="menuitem" href="https://library.stanford.edu/using/interlibrary-borrowing">Interlibrary services</a>
+        <a role="menuitem" href="https://library.stanford.edu/ask/email/reference">Email a reference question</a>
+      </li>
+      <li>
+        <a role="menuitem" href="https://library.stanford.edu/people">Find a subject specialist</a>
       </li>
     </ul>
   </li>
@@ -14,44 +17,10 @@
     <span class="menugroup">Connection</span>
     <ul>
       <li>
-        <a role="menuitem" href="https://library.stanford.edu/ask/email/reference">Ask a reference question</a>
-      </li>
-      <li>
+        <li>
+          <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">Connect to e-resources</a>
+        </li>
         <a role="menuitem" href="https://library.stanford.edu/ask/email/connection-problems">Report a connection problem</a>
-      </li>
-      <li>
-        <a role="menuitem" href="https://library.stanford.edu/suggest_purchase">Suggest a purchase (requires login)</a>
-      </li>
-    </ul>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/about">About the Stanford Libraries</a>
-    <ul>
-      <li>
-        <a role="menuitem" href="https://library.stanford.edu/people">Find a specialist</a>
-      </li>
-      <li>
-        <a role="menuitem" href="https://library-hours.stanford.edu/">Library hours</a>
-      </li>
-    </ul>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/libraries">Libraries</a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/collections">Collections</a>
-  </li>
-  <li>
-    <a role="menuitem" href="https://library.stanford.edu/research">Research support</a>
-    <ul>
-      <li>
-        <a role="menuitem" href="https://library.stanford.edu/guides/topic">Topic guides</a>
-      </li>
-      <li>
-        <a role="menuitem" href="https://library.stanford.edu/guides/course">Course guides</a>
-      </li>
-      <li>
-        <a role="menuitem" href="https://library.stanford.edu/search-tools">More search tools</a>
       </li>
     </ul>
   </li>

--- a/app/views/shared/_services_menu.html.erb
+++ b/app/views/shared/_services_menu.html.erb
@@ -1,6 +1,6 @@
 <ul class="dropdown-menu sul-services-menu" role="menu">
   <li>
-    <a role="menuitem" href="https://library.stanford.edu/using">Using the libraries</a>
+    <span class="menugroup">Need help?</span>
     <ul>
       <li>
         <a role="menuitem" href="https://library.stanford.edu/using/connect-campus">Connecting to e-resources</a>
@@ -11,7 +11,7 @@
     </ul>
   </li>
   <li>
-    <a role="menuitem" href="https://library.stanford.edu/ask">Ask us</a>
+    <span class="menugroup">Connection</span>
     <ul>
       <li>
         <a role="menuitem" href="https://library.stanford.edu/ask/email/reference">Ask a reference question</a>

--- a/app/views/shared/_sub_navbar.html.erb
+++ b/app/views/shared/_sub_navbar.html.erb
@@ -1,8 +1,8 @@
 <div id="subnavbar-container">
   <div id="subnavbar">
     <ul class="nav navbar-nav navbar-expand-sm">
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">
+      <li class="nav-item dropdown mr-3">
+        <a id="services" class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">
           Help<span class="caret"/>
         </a>
         <%= render :partial => '/shared/services_menu' %>

--- a/app/views/shared/_sub_navbar.html.erb
+++ b/app/views/shared/_sub_navbar.html.erb
@@ -3,7 +3,7 @@
     <ul class="nav navbar-nav navbar-left">
       <li class="dropdown search-subnavbar-about">
         <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-          Library services<span class="caret"/>
+          Help<span class="caret"/>
         </a>
         <%= render :partial => '/shared/services_menu' %>
       </li>

--- a/app/views/shared/_sub_navbar.html.erb
+++ b/app/views/shared/_sub_navbar.html.erb
@@ -1,11 +1,16 @@
 <div id="subnavbar-container">
   <div id="subnavbar">
-    <ul class="nav navbar-nav navbar-left">
-      <li class="dropdown search-subnavbar-about">
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+    <ul class="nav navbar-nav navbar-expand-sm">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">
           Help<span class="caret"/>
         </a>
         <%= render :partial => '/shared/services_menu' %>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link covid-status" href="https://library.stanford.edu/status" >
+          COVID-19 Libraries update
+        </a>
       </li>
     </ul>
   </div>

--- a/spec/views/shared/_sub_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_sub_navbar.html.erb_spec.rb
@@ -9,8 +9,8 @@ describe 'shared/_sub_navbar.html.erb' do
     end
   end
 
-  it 'renders the library services menus' do
+  it 'renders the help menu' do
     render
-    expect(rendered).to have_link 'Library services'
+    expect(rendered).to have_link 'Help'
   end
 end


### PR DESCRIPTION
Closes #397

This PR:
- adds a link to our COVID-19 status page
- renames the `Library services` menu to `Help`
- removes several links and subheadings
- cleans up some unused CSS, updates dropdown classes to new Bootstrappy 4.3 versions

I'm deploying this to bento stage if anyone wants to take a second look there.

### Before
<img width="365" alt="services-menu-before" src="https://user-images.githubusercontent.com/5402927/94204617-6b6b1f80-fe76-11ea-82e7-89fe508182ff.png">

### After
<img width="455" alt="services-menu-after" src="https://user-images.githubusercontent.com/5402927/94204610-68702f00-fe76-11ea-970d-e60109712769.png">
