### PR TITLE
method signatures didn't seem to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 2. Run `bundle exec rails s -p 3000`
 3. Now, you can visit http://localhost:3000/ for the Bento app
 
+
+## Example of running a search from the Rails console
+
+```
+client = HTTP.timeout(30)
+article_search = QuickSearch::ArticleSearcher.new(client, "covid").search
+# could also be CatalogSearcher or ExhibitsSearcher
+article_search.total # total number of search results
+article_search.results.size # total number of results actually returned for display, configurable with NUM_RESULTS_SHOWN in settings.yml
+article_search.results[0].title # title of the search
+article_search.results[0].link # link to the results
+```
+
 Some of the code in this repository was extracted from [NCSU/quick_search](https://github.com/NCSU-Libraries/quick_search).
 ```
 Copyright 2016 North Carolina State University

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,7 @@ class SearchController < ApplicationController
 
     @query = params_q_scrubbed
 
-    searcher = search_service.one(endpoint, @query)
+    searcher = search_service.one(endpoint)
 
     respond_to do |format|
       format.html {

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,7 @@ class SearchController < ApplicationController
 
     @query = params_q_scrubbed
 
-    searcher = search_service.one(endpoint)
+    searcher = search_service.one(endpoint, @query)
 
     respond_to do |format|
       format.html {

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -29,7 +29,7 @@ class SearchService
     searches
   end
 
-  def one(searcher, timeout: 30)
+  def one(searcher, query, timeout: 30)
     benchmark "%s #{searcher}" % CGI.escape(query.to_str) do
       klass = case searcher
       when Class

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -17,7 +17,7 @@ class SearchService
 
         Thread.new(search_method) do |sm|
           begin
-            searches[search_method] = one(klass, query, timeout: Settings.quick_search.http_timeout)
+            searches[search_method] = one(klass, timeout: Settings.quick_search.http_timeout)
           rescue StandardError => e
             logger.info "FAILED SEARCH: #{search_method} | #{query} | #{e}"
           end
@@ -29,7 +29,7 @@ class SearchService
     searches
   end
 
-  def one(searcher, query, timeout: 30)
+  def one(searcher, timeout: 30)
     benchmark "%s #{searcher}" % CGI.escape(query.to_str) do
       klass = case searcher
       when Class


### PR DESCRIPTION
1. Updates to readme to show how you can run a search manually on the rails console (I found this useful)
2. Noted when running the app locally that I was seeing some errors in the logs like this:

```
FAILED SEARCH: catalog | covid-19 | wrong number of arguments (given 2, expected 1)
FAILED SEARCH: library_website_api | covid-19 | wrong number of arguments (given 2, expected 1)
FAILED SEARCH: exhibits | covid-19 | wrong number of arguments (given 2, expected 1)
FAILED SEARCH: lib_guides | covid-19 | wrong number of arguments (given 2, expected 1)
FAILED SEARCH: article | covid-19 | wrong number of arguments (given 2, expected 1)
```

When I looked at the method signatures, it seems like they didn't match (even though the app was working ok in the browser).  Made changes, errors in log went away, app still works? 

Note: the change I made to the method signature matches an existing call in the code here (which is where the log errors were coming from): https://github.com/sul-dlss/sul-bento-app/blob/master/app/services/search_service.rb#L20