### PR TITLE
Update to the new Yewno widget

### DIFF
--- a/app/assets/javascripts/yewno.js
+++ b/app/assets/javascripts/yewno.js
@@ -1,9 +1,11 @@
 
 $(window).ready(function() {
   $("#yewno-results").each(function(t) {
-    new YewnoDiscoverWidget({
+    new YewnoRelate({
       containerElementSelector: "#yewno-results",
       urlSearchParam: "q",
+      linkDiscover: true,
+      definitionCount: 0,
       urlPrefix: "https://stanford.idm.oclc.org/login?url="
     })
   });

--- a/app/assets/stylesheets/modules/yewno.scss
+++ b/app/assets/stylesheets/modules/yewno.scss
@@ -1,9 +1,6 @@
 #yewno {
   border-top: 5px solid $black;
 }
-.yewno #yewno-results {
-  height: 400px;
-}
 
 .yn-figcaption {
   text-align: center;
@@ -13,4 +10,54 @@
   @include button-variant($black, $black);
   font-family: 'Source Sans Pro', 'Arial Unicode MS', Helvetica, sans-serif;
   display: inline-block;
+}
+
+.yn-header {
+  display: none !important;
+}
+
+.yn-concept-definitions-container {
+  display: none !important;
+}
+
+// give the "connections" navigation actual space.
+.yn-pagination {
+  height: auto !important;
+  padding-bottom: 0 !important;
+}
+
+// tooltips from the widget should appear above the buttons below.
+.yn-widget {
+  z-index: 500;
+}
+
+.yewno #yewno-results {
+  height: auto !important;
+}
+
+.yn-concept-tooltip {
+  // yewno inherits our document color which has insufficient contrast
+  // with their background.
+  h3 {
+    color: #fff;
+  }
+}
+
+.yn-footer {
+  // original spacing was 5px
+  margin-top: 1rem !important;
+
+  // align the button and branding to the edges of the container.
+  .yn-link-discover-btn {
+    left: 0 !important;
+
+    // fixed height and padding makes the button text
+    // look off-center.
+    height: auto !important;
+    padding: 0 !important;
+  }
+
+  .yn-footer-discover {
+    margin-right: 0 !important;
+  }
 }


### PR DESCRIPTION
Fixes #505 

We hide a bunch text to clean up the display, and we hide the discover link because they took away the configuration that sends users through ezproxy.

![Screen Shot 2022-07-27 at 08 45 38](https://user-images.githubusercontent.com/111218/181291237-95614626-9d14-4507-958e-ca4c9ae6128a.png)

---

before our styling hacks:

![Screen Shot 2022-07-27 at 08 44 43](https://user-images.githubusercontent.com/111218/181291311-487be94d-66d9-487f-aa9d-8e9c79fa2de4.png)

