### PR TITLE
Stop using font-url

### DIFF
--- a/app/assets/stylesheets/application/deja-vu-font.scss
+++ b/app/assets/stylesheets/application/deja-vu-font.scss
@@ -1,10 +1,10 @@
 @font-face {
   font-family: 'dejavu_sansextralight';
-  src: font-url('DejaVuSans-ExtraLight-webfont.eot');
-  src: font-url('DejaVuSans-ExtraLight-webfont.eot?#iefix') format('embedded-opentype'),
-       font-url('DejaVuSans-ExtraLight-webfont.woff') format('woff'),
-       font-url('DejaVuSans-ExtraLight-webfont.ttf') format('truetype'),
-       font-url('DejaVuSans-ExtraLight-webfont.svg#dejavu_sansextralight') format('svg');
+  src: url('DejaVuSans-ExtraLight-webfont.eot');
+  src: url('DejaVuSans-ExtraLight-webfont.eot?#iefix') format('embedded-opentype'),
+       url('DejaVuSans-ExtraLight-webfont.woff') format('woff'),
+       url('DejaVuSans-ExtraLight-webfont.ttf') format('truetype'),
+       url('DejaVuSans-ExtraLight-webfont.svg#dejavu_sansextralight') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
It is no longer necessary and prevents the font from loading

This fixes the following error:
```
Unknown descriptor ‘font-url(’ in @font-face rule.  Skipped to next declaration.
```