### PR TITLE
changing to GA4 support, removing older tag manager code

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,18 +16,13 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
     
     <!-- Google tag (gtag.js) --> 
-    <meta name="analytics_debug" value="<%= ENV.fetch('ANALYTICS_DEBUG', 1) %>">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-4H0K34LTNE"></script> 
     <script> 
-      const debug = document.head.querySelector("meta[name=analytics_debug]").getAttribute("value") === "1";
       window.dataLayer = window.dataLayer || []; 
       function gtag(){dataLayer.push(arguments);} 
       // To turn off debug mode, exclude the parameter altogether (cannot just set to false)
       // See https://support.google.com/analytics/answer/7201382?hl=en#zippy=%2Cgoogle-tag-websites
-      const args = {}
-      if (debug) {
-        args["debug_mode"] = debug;
-      } 
+      args = <%= Settings.analytics_debug %> ? {"debug_mode":true} : {};
       gtag('js', new Date()); 
       gtag('config', 'G-4H0K34LTNE', args); 
     </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,6 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
   <head>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-M6F99S9');</script>
-    <!-- End Google Tag Manager -->
     <title><%= content_for(:title) %></title>
     <%= favicon_link_tag 'favicon.ico' %>
     <meta content="ie=edge, chrome=1" http-equiv="x-ua-compatible"/>
@@ -21,16 +14,24 @@
     <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700' rel='stylesheet' type='text/css'>
     <%= javascript_include_tag 'application' %>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
-    <% if Settings.GOOGLE_ANALYTICS_ID.present? %>
-    <script>
-    // Universal analytics
-    (function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","//www.google-analytics.com/analytics.js","ga");
-
-    ga("create", "<%= Settings.GOOGLE_ANALYTICS_ID %>", "auto");
-    ga("send", "pageview");
-
+    
+    <!-- Google tag (gtag.js) --> 
+    <meta name="analytics_debug" value="<%= ENV.fetch('ANALYTICS_DEBUG', 1) %>">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4H0K34LTNE"></script> 
+    <script> 
+      const debug = document.head.querySelector("meta[name=analytics_debug]").getAttribute("value") === "1";
+      window.dataLayer = window.dataLayer || []; 
+      function gtag(){dataLayer.push(arguments);} 
+      // To turn off debug mode, exclude the parameter altogether (cannot just set to false)
+      // See https://support.google.com/analytics/answer/7201382?hl=en#zippy=%2Cgoogle-tag-websites
+      const args = {}
+      if (debug) {
+        args["debug_mode"] = debug;
+      } 
+      gtag('js', new Date()); 
+      gtag('config', 'G-4H0K34LTNE', args); 
     </script>
-    <% end %>
+    <!-- Google tag (gtag.js) -->
     <%= stylesheet_link_tag "application" %>
 
   </head>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,3 +44,4 @@ quick_search:
   http_timeout: 1.5
   xhr_http_timeout: 15
   doi_loaded_link: "http://doi.org/"
+analytics_debug: true


### PR DESCRIPTION
Relates to https://github.com/sul-dlss/sul-bento-app/issues/539 