### PR TITLE
Fix guide results toggle

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import 'custom_quick_search';
-import 'toggleableResults';
+import toggleableResults from 'toggleableResults';
+window.toggleableResults = toggleableResults;

--- a/app/javascript/toggleableResults.js
+++ b/app/javascript/toggleableResults.js
@@ -1,4 +1,4 @@
-function toggleableResults(searcher) {
+export default function(searcher) {
   var toggleableResults = $('#' + searcher + ' [data-behavior="toggleable-results"]');
   var threshold = toggleableResults.data('toggleThreshold');
   var toggleButton = $('#' + searcher + '-results-toggle-button');
@@ -23,4 +23,4 @@ function toggleableResults(searcher) {
       toggleButton.attr('aria-expanded', false);
     }
   });
-}
+};

--- a/app/views/search/_module.html.erb
+++ b/app/views/search/_module.html.erb
@@ -25,7 +25,9 @@
             </button>
 
             <script type='text/javascript'>
-              toggleableResults('<%= service_name %>');
+              window.onload = function () { 
+                toggleableResults('<%= service_name %>');
+              };
             </script>
           <% end %>
 


### PR DESCRIPTION
@jcoyne after I merged https://github.com/sul-dlss/sul-bento-app/pull/698 I noticed that `toggleableResults` wasn't working so all the guide results are being shown on the results page instead of getting truncated. This PR gets it working, but maybe there's a better fix?

Before:
<img width="673" alt="Screenshot 2024-11-04 at 10 22 19 AM" src="https://github.com/user-attachments/assets/1e39afbc-123c-4a0a-9235-1555ff930a4a">

After: 
<img width="665" alt="Screenshot 2024-11-04 at 10 23 29 AM" src="https://github.com/user-attachments/assets/e9ac7587-ad98-439b-83ad-f9eb2ce7ceff">
