### PR TITLE
make guides not toggleable, fix guides results total display

### DIFF
--- a/app/searchers/quick_search/lib_guides_searcher.rb
+++ b/app/searchers/quick_search/lib_guides_searcher.rb
@@ -11,13 +11,5 @@ module QuickSearch
     def loaded_link
       format(Settings.LIBGUIDES.QUERY_URL.to_s, q: CGI.escape(q.to_s))
     end
-
-    def toggleable?
-      true
-    end
-
-    def toggle_threshold
-      Settings.LIBGUIDES.NUM_RESULTS_SHOWN
-    end
   end
 end

--- a/app/services/lib_guides_search_service.rb
+++ b/app/services/lib_guides_search_service.rb
@@ -24,7 +24,7 @@ class LibGuidesSearchService < AbstractSearchService
 
   class Response < AbstractSearchService::Response
     def results
-      json.collect do |doc|
+      json.first(num_results).collect do |doc|
         result = AbstractSearchService::Result.new
         result.title = doc['name']
         result.link = doc['url']
@@ -33,12 +33,20 @@ class LibGuidesSearchService < AbstractSearchService
       end
     end
 
+    def num_results
+      Settings.LIBGUIDES.NUM_RESULTS_SHOWN
+    end
+
     def facets
       []
     end
 
+    # The guides api will only return 100 results
+    # If there are more than 100 results there is no way of knowing the correct number
+    # Instead of displaying a correct number we don't display the number if the results == 100
+    # Otherwise we have a correct length and can display the number of results.
     def total
-      json.length
+      json.length == 100 ? '100+' : json.length
     end
 
     private

--- a/spec/searchers/quick_search/lib_guides_searcher_spec.rb
+++ b/spec/searchers/quick_search/lib_guides_searcher_spec.rb
@@ -6,17 +6,36 @@ RSpec.describe QuickSearch::LibGuidesSearcher do
   subject(:searcher) { described_class.new(HTTP, query, 10) }
 
   let(:query) { 'my query' }
-  let(:response) { JSON.dump([]) }
+  let(:response_hash) { { name: 'name' } }
+  let(:response) { JSON.dump(response_list) }
 
   before do
     stub_request(:get, /.*/).to_return(body: response)
   end
 
-  it { expect(searcher.search).to be_an(LibGuidesSearchService::Response) }
-  it { expect(searcher).to be_toggleable }
-  it { expect(searcher.toggle_threshold).to be 3 }
-  it do
-    searcher.search # loads response
-    expect(searcher.results).to be_an(Array)
+  context 'with 100 results' do
+    let(:response_list) { Array.new(100) { response_hash.dup } }
+
+    it { expect(searcher.search).to be_an(LibGuidesSearchService::Response) }
+
+    it do
+      searcher.search # loads response
+      expect(searcher.results).to be_an(Array)
+      expect(searcher.results.length).to be 3
+      expect(searcher.total).to be '100+'
+    end
+  end
+
+  context 'with 55 results' do
+    let(:response_list) { Array.new(55) { response_hash.dup } }
+
+    it { expect(searcher.search).to be_an(LibGuidesSearchService::Response) }
+
+    it do
+      searcher.search # loads response
+      expect(searcher.results).to be_an(Array)
+      expect(searcher.results.length).to be 3
+      expect(searcher.total).to be 55
+    end
   end
 end


### PR DESCRIPTION
closes #748 

**No results**
![Screenshot 2025-05-12 at 3 16 44 PM](https://github.com/user-attachments/assets/5a3254f2-1bfd-4ad6-bf2a-9823bdfc75c4)

**55 results**
![Screenshot 2025-05-12 at 3 16 08 PM](https://github.com/user-attachments/assets/0dd165c0-567f-4067-944e-6066b2cefb2f)

**223 results, which we aren't able to easily get the correct number**
<img width="490" alt="Screenshot 2025-05-14 at 10 33 34 AM" src="https://github.com/user-attachments/assets/68fed4a6-6574-4c29-8ef5-ff56fe45b2c5" />
