### PR TITLE
Adjust padding on search result page

### DIFF
--- a/app/views/search/_found_types.html.erb
+++ b/app/views/search/_found_types.html.erb
@@ -1,4 +1,4 @@
-<nav class="searcher-anchors my-4 d-flex justify-content-center gap-4 mb-3" aria-label="Results found in">
+<nav class="searcher-anchors my-4 d-flex justify-content-center gap-4" aria-label="Results found in">
   <span class="fw-semibold fs-1125 text-nowrap align-self-start">Results from:</span>
   <ul class="d-flex flex-wrap align-self-center list-inline column-gap-4 row-gap-2 mb-0">
     <% Settings.ENABLED_SEARCHERS.each do |searcher| %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -16,7 +16,7 @@
     </div>
   </div>
 
-  <div class="row">
+  <div class="row my-3">
     <div class="col-xl-9 col-lg-12">
       <div class="d-flex flex-wrap gap-5 mt-3" id="modules">
         <% Settings.ENABLED_SEARCHERS.each do |searcher| %>


### PR DESCRIPTION
Before:
![Screenshot 2025-06-11 at 15-23-35 frog Search Stanford Libraries](https://github.com/user-attachments/assets/c4879500-94f3-450f-b7c2-f4c7650942df)


After
![Screenshot 2025-06-11 at 15-27-00 frog Search Stanford Libraries](https://github.com/user-attachments/assets/89b5a847-2ac5-47b1-8e97-27822df8e9ef)

