### PR TITLE
Reduce the allowed RSpec/MultipleExpectations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,7 @@ RSpec/ExampleLength:
   Max: 12
 
 RSpec/MultipleExpectations:
-  Max: 12
+  Max: 3
 
 Style/StringLiterals:
   Enabled: true

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -8,18 +8,20 @@ RSpec.feature 'Homepage', :js do
   end
 
   scenario 'has text for top level headings and sections for search tools and other sources' do
+    aggregate_failures do
+      # High leavel headings
+      expect(page).to have_text 'Stanford University Libraries\' search tools'
+      expect(page).to have_text 'Other sources searched'
+
+      # First two search tools sections
+      expect(page).to have_text 'SearchWorks Catalog'
+      expect(page).to have_text 'SearchWorks Articles+'
+
+      # First two
+      expect(page).to have_text 'Library website'
+      expect(page).to have_text 'Guides'
+    end
+
     expect(page).to be_accessible
-
-    # High leavel headings
-    expect(page).to have_text 'Stanford University Libraries\' search tools'
-    expect(page).to have_text 'Other sources searched'
-
-    # First two search tools sections
-    expect(page).to have_text 'SearchWorks Catalog'
-    expect(page).to have_text 'SearchWorks Articles+'
-
-    # First two
-    expect(page).to have_text 'Library website'
-    expect(page).to have_text 'Guides'
   end
 end

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe 'Search results', :js do
       expect(page).to have_css('.btn-outline-secondary')
       expect(page).to have_css('#article a', text: /See all 666,666\sarticle\sresults/)
       within '.searcher-anchors' do
-        expect(page).to have_link 'Articles+', href: '#article'
-        expect(page).to have_css '#article_count', text: '666,666'
+        expect(page).to have_link('Articles+', href: '#article').and have_css '#article_count', text: '666,666'
       end
     end
   end

--- a/spec/services/exhibits_search_service_spec.rb
+++ b/spec/services/exhibits_search_service_spec.rb
@@ -23,10 +23,12 @@ RSpec.describe ExhibitsSearchService do
     it 'returns the relevant metadata from the API' do
       results = service.search(query).results
       expect(results.length).to eq 3
-      expect(results.first.title).to eq '!Women Art Revolution'
-      expect(results.first.description).to eq 'Voices of a Movement'
-      expect(results.first.link).to eq 'https://exhibits.stanford.edu/women-art-revolution'
-      expect(results.first.thumbnail).to eq 'https://exhibits.stanford.edu/images/670/31,22,462,462/400,400/0/default.jpg'
+      expect(results.first).to have_attributes(
+        title: '!Women Art Revolution',
+        description: 'Voices of a Movement',
+        link: 'https://exhibits.stanford.edu/women-art-revolution',
+        thumbnail: 'https://exhibits.stanford.edu/images/670/31,22,462,462/400,400/0/default.jpg'
+      )
     end
   end
 end

--- a/spec/services/library_website_api_search_service_spec.rb
+++ b/spec/services/library_website_api_search_service_spec.rb
@@ -75,9 +75,11 @@ RSpec.describe LibraryWebsiteApiSearchService do
     it 'sets the title, description, and link in the document' do
       results = service.search(query).results
       expect(results.length).to eq 2
-      expect(results.first.title).to eq 'Work with data'
-      expect(results.first.description).to eq 'First result description'
-      expect(results.first.link).to eq '/services/work-data'
+      expect(results.first).to have_attributes(
+        title: 'Work with data',
+        description: 'First result description',
+        link: '/services/work-data'
+      )
     end
   end
 


### PR DESCRIPTION
I don't think we aspire to lots of rspec expectations in a single test.