### PR TITLE
Don't show the button if there are zero results

### DIFF
--- a/app/views/search/_module_heading.html.erb
+++ b/app/views/search/_module_heading.html.erb
@@ -2,7 +2,7 @@
     <h2 class='result-set-heading h4 mb-0 fw-semibold text-nowrap'>
       <%= t("#{service_name}_search.display_name_html") %>
     </h2>
-    <%= render '/search/see_all', { service_name: service_name, total: total, module_link: searcher.loaded_link } %>
+    <%= render '/search/see_all', { service_name: service_name, total: total, module_link: searcher.loaded_link } unless total == '0' %>
 </div>
 <small class='result-set-subheading d-block mb-3'>
   <%= t("#{service_name}_search.sub_heading_html") %>


### PR DESCRIPTION
This fixes a regression where we are currently showing a button for "0" results
Before
<img width="489" alt="Screenshot 2025-06-12 at 10 16 58 AM" src="https://github.com/user-attachments/assets/d5773245-b5ac-45c3-a518-f6a2365348d5" />


After
<img width="482" alt="Screenshot 2025-06-12 at 10 17 20 AM" src="https://github.com/user-attachments/assets/e6c5f241-d93b-4d5c-8e81-18c8b32181a9" />
