### PR TITLE
fix full-text badge color

### DIFF
--- a/app/assets/stylesheets/modules/results.css
+++ b/app/assets/stylesheets/modules/results.css
@@ -16,7 +16,7 @@
 }
 
 .online-label {
-  background-color: rgb(var(--stanford-illuminating-light-rgb));
+  background-color: rgb(var(--stanford-illuminating-light-rgb), 0.5);
 
   --bs-badge-font-weight: 600;
   --bs-badge-color: var(--bs-body-color);


### PR DESCRIPTION
Before:
<img width="737" alt="Screenshot 2025-06-12 at 6 06 28 PM" src="https://github.com/user-attachments/assets/6a99f3d0-4be1-449d-9579-cee91966a350" />

After: 
<img width="751" alt="Screenshot 2025-06-12 at 6 06 18 PM" src="https://github.com/user-attachments/assets/75fda873-8b28-462b-a24c-6d2d97fc6b52" />

Figma:
<img width="729" alt="Screenshot 2025-06-12 at 6 06 32 PM" src="https://github.com/user-attachments/assets/2d736949-6b90-409d-8892-1246c1ad1d11" />
