### PR TITLE
Align icon to the first line of text in the physical description

### DIFF
--- a/app/views/search/_result_details.html.erb
+++ b/app/views/search/_result_details.html.erb
@@ -4,7 +4,7 @@
 
 
 <% if result.icon.present? || result.physical %>
-  <div class="pb-1 d-flex align-items-center">
+  <div class="pb-1 ">
     <%= image_tag result.icon, aria: { hidden: true }, class: 'icon mx-1' %>
     <span class="fw-semibold"><%= result.format %></span>
     <% if result.physical %>


### PR DESCRIPTION
<img width="739" alt="Screenshot 2025-06-13 at 1 29 54 PM" src="https://github.com/user-attachments/assets/b77303ae-71cc-4db4-922c-7847063ffd57" />

Fixes #816
