### PR TITLE
convert stanford only icon to popover

### DIFF
--- a/app/assets/stylesheets/modules/results.css
+++ b/app/assets/stylesheets/modules/results.css
@@ -9,10 +9,23 @@
   }
 }
 
-.stanford-only::after {
+/* Rip out when https://github.com/sul-dlss/SearchWorks/pull/5129 is merged */
+.stanford-only:not(.btn)::after {
   content: url("/stanford-only.svg");
   margin-left: 5px;
   vertical-align: middle;
+}
+
+.stanford-only.btn-primary {
+  --bs-btn-bg: none;
+  --bs-btn-border-color: none;
+  --bs-btn-hover-bg: none;
+  --bs-btn-active-bg: none;
+  --bs-btn-active-border-color: none;
+  --bs-btn-padding-y: 0;
+  --bs-btn-padding-x: 0.25rem;
+
+  vertical-align: baseline;
 }
 
 .online-label {

--- a/app/javascript/controllers/module_controller.js
+++ b/app/javascript/controllers/module_controller.js
@@ -5,5 +5,7 @@ export default class extends Controller {
 
   connect() {
     document.getElementById(this.countIdValue).innerText = this.totalValue;
+    const popovers = document.querySelectorAll('[data-bs-toggle="popover"]')
+    popovers.forEach(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl))
   }
 }

--- a/app/services/article_search_service.rb
+++ b/app/services/article_search_service.rb
@@ -34,9 +34,8 @@ class ArticleSearchService < AbstractSearchService
           online_label['class'] += ' badge rounded-pill ms-2'
           result.title += online_label.to_html
         end
-        stanford_only = html.css('.stanford-only').first
         result.fulltext_link_html = html.css('a').first&.to_html
-        result.fulltext_link_html += stanford_only.to_html if stanford_only
+        result.fulltext_link_html += stanford_only(html)
         result.author = doc['eds_authors']&.first
         # result.year = doc['pub_year_tisim']&.html_safe
         result.description = doc['eds_abstract']
@@ -45,6 +44,14 @@ class ArticleSearchService < AbstractSearchService
     end
 
     private
+
+    def stanford_only(html)
+      # Rip out html.css('.stanford-only').first when https://github.com/sul-dlss/SearchWorks/pull/5129 is merged
+      stanford_only = html.css('[aria-label="Stanford-only"]').first || html.css('.stanford-only').first
+      return stanford_only.to_html if stanford_only
+
+      ''
+    end
 
     def json
       @json ||= JSON.parse(@body)


### PR DESCRIPTION
This will continue working until we switch over the SearchWorks to return the popover for the API

![Screenshot 2025-06-13 at 3 41 46 PM](https://github.com/user-attachments/assets/0a6c41b2-ce49-48eb-ba50-5698d8117e77)
