### PR TITLE
Handle empty results for lib_guides

### DIFF
--- a/app/services/abstract_search_service.rb
+++ b/app/services/abstract_search_service.rb
@@ -36,6 +36,12 @@ class AbstractSearchService
     def results
       raise NotImplementedError
     end
+
+    private
+
+    def json
+      @json ||= JSON.parse(@body)
+    end
   end
 
   def initialize(options = {})
@@ -46,14 +52,16 @@ class AbstractSearchService
 
   # @param [String] query
   def search(query)
-    url = format(@query_url, q: CGI.escape(query), max: Settings.MAX_RESULTS)
-
-    response = @http.get(url)
+    response = @http.get(url(query))
 
     unless response.status.success? && response.body.present?
       raise NoResults, "Search response failed: #{url} status: #{response.status} body #{response.body}"
     end
 
     @response_class.new(response.body.to_s)
+  end
+
+  def url(query)
+    format(@query_url, q: CGI.escape(query), max: Settings.MAX_RESULTS)
   end
 end

--- a/app/services/archives_search_service.rb
+++ b/app/services/archives_search_service.rb
@@ -38,11 +38,5 @@ class ArchivesSearchService < AbstractSearchService
         'file.svg'
       end
     end
-
-    private
-
-    def json
-      @json ||= JSON.parse(@body)
-    end
   end
 end

--- a/app/services/article_search_service.rb
+++ b/app/services/article_search_service.rb
@@ -52,9 +52,5 @@ class ArticleSearchService < AbstractSearchService
 
       ''
     end
-
-    def json
-      @json ||= JSON.parse(@body)
-    end
   end
 end

--- a/app/services/catalog_search_service.rb
+++ b/app/services/catalog_search_service.rb
@@ -34,11 +34,5 @@ class CatalogSearchService < AbstractSearchService
         result
       end
     end
-
-    private
-
-    def json
-      @json ||= JSON.parse(@body)
-    end
   end
 end

--- a/app/services/earthworks_search_service.rb
+++ b/app/services/earthworks_search_service.rb
@@ -24,11 +24,5 @@ class EarthworksSearchService < AbstractSearchService
         )
       end
     end
-
-    private
-
-    def json
-      @json ||= JSON.parse(@body)
-    end
   end
 end

--- a/app/services/exhibits_search_service.rb
+++ b/app/services/exhibits_search_service.rb
@@ -40,9 +40,5 @@ class ExhibitsSearchService < AbstractSearchService
     def settings
       Settings.exhibits
     end
-
-    def json
-      @json ||= JSON.parse(@body)
-    end
   end
 end

--- a/app/services/lib_guides_search_service.rb
+++ b/app/services/lib_guides_search_service.rb
@@ -22,6 +22,21 @@ class LibGuidesSearchService < AbstractSearchService
     ].join()
   end
 
+  # @param [String] query
+  def search(query)
+    response = @http.get(url(query))
+
+    body = if response.status.success? && response.body.present?
+             response.body.to_s
+           elsif response.status == 404
+             '[]'
+           else
+             raise NoResults
+           end
+
+    @response_class.new(body)
+  end
+
   class Response < AbstractSearchService::Response
     def results
       json.first(num_results).collect do |doc|
@@ -42,12 +57,6 @@ class LibGuidesSearchService < AbstractSearchService
     # Otherwise we have a correct length and can display the number of results.
     def total
       json.length == 100 ? '100+' : json.length
-    end
-
-    private
-
-    def json
-      @json ||= JSON.parse(@body)
     end
   end
 end

--- a/app/services/library_website_api_search_service.rb
+++ b/app/services/library_website_api_search_service.rb
@@ -26,11 +26,5 @@ class LibraryWebsiteApiSearchService < AbstractSearchService
     def total
       json.dig('meta', 'count')
     end
-
-    private
-
-    def json
-      @json ||= JSON.parse(@body)
-    end
   end
 end

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'Search results', :js do
     end
 
     before do
+      allow_any_instance_of(LibGuidesSearchService).to receive(:search).and_return(response)
       allow_any_instance_of(AbstractSearchService).to receive(:search).and_return(response)
 
       visit search_path
@@ -37,6 +38,7 @@ RSpec.describe 'Search results', :js do
 
   context 'when a searcher times out' do
     before do
+      allow_any_instance_of(LibGuidesSearchService).to receive(:search).and_return(response)
       allow_any_instance_of(ArticleSearchService).to receive(:search).and_raise(HTTP::TimeoutError)
       allow_any_instance_of(AbstractSearchService).to receive(:search).and_return(response)
 

--- a/spec/services/lib_guides_search_service_spec.rb
+++ b/spec/services/lib_guides_search_service_spec.rb
@@ -49,4 +49,34 @@ RSpec.describe LibGuidesSearchService do
       expect(results.first.title).to eq 'World languages education'
     end
   end
+
+  describe '#search' do
+    subject(:search) { service.search(query) }
+
+    context 'when response is successful' do
+      it 'returns a response object' do
+        expect(search).to be_an LibGuidesSearchService::Response
+      end
+    end
+
+    context 'when response is 404' do
+      before do
+        stub_request(:get, /.*/).to_return(status: 404)
+      end
+
+      it 'returns a empty result' do
+        expect(search).to be_an LibGuidesSearchService::Response
+      end
+    end
+
+    context 'when response is an error' do
+      before do
+        stub_request(:get, /.*/).to_return(status: 500)
+      end
+
+      it 'raises an error' do
+        expect { search }.to raise_error(AbstractSearchService::NoResults)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Rather than a 200 status with no results, lib_guides returns a 404 reponse. This change adjusts the response so that we still see 'No results' on the page.