### PR TITLE
Add margin-bottom to module headers

### DIFF
--- a/app/views/search/_module_heading.html.erb
+++ b/app/views/search/_module_heading.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex justify-content-between align-items-center flex-wrap column-gap-1 mb-1">
-    <h2 class='result-set-heading h4 mb-0 fw-semibold text-nowrap'>
+    <h2 class='result-set-heading h4 mb-1 fw-semibold text-nowrap'>
       <%= t("#{service_name}_search.display_name_html") %>
     </h2>
     <%= render '/search/see_all', { service_name: service_name, total: searcher.total, see_all_link: searcher.see_all_link } unless searcher.total.zero? %>


### PR DESCRIPTION
Fixes #836

Before:
<img width="400" alt="Screenshot 2025-06-16 at 2 18 28 PM" src="https://github.com/user-attachments/assets/7fca701f-6717-42fb-baf0-d1d0781313c4" />

After:
<img width="411" alt="Screenshot 2025-06-16 at 2 17 58 PM" src="https://github.com/user-attachments/assets/9581780e-c3e6-4933-9a16-69e4fdd2a6b4" />

