### PR TITLE
Remove unused no-js class.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" lang="en">
+<html lang="en">
   <head>
     <title><%= content_for(:title) %></title>
     <link rel="icon" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-06-10/styles/icon.png" type="image/png">


### PR DESCRIPTION
We're not doing anything with this any more (and we're no longer removing it either, so it's a little confusing.)