### PR TITLE
Remove unnecessary bootstrap popover initialization 

### DIFF
--- a/app/javascript/controllers/module_controller.js
+++ b/app/javascript/controllers/module_controller.js
@@ -5,7 +5,5 @@ export default class extends Controller {
 
   connect() {
     document.getElementById(this.countIdValue).innerText = this.totalValue;
-    const popovers = document.querySelectorAll('[data-bs-toggle="popover"]')
-    popovers.forEach(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl))
   }
 }


### PR DESCRIPTION
Unless my local assets are wrong (which is a strong possibility?), the the bootstrap bundle package does this for us?