### PR TITLE
Fix a typo to get the default bootstrap navbar/dropdown behavior.

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -41,7 +41,7 @@
         <div class="masthead lg-shadow">
           <div class="container-fluid">
             <div class="d-flex flex-wrap align-items-end justify-content-between gap-3">
-              <div class="navbars ms-lg-auto">
+              <div class="navbar ms-lg-auto">
                 <nav class="collapse navbar-collapse align-items-start justify-content-lg-end navbar-expand-lg d-lg-flex flex-column flex-lg-row" aria-label="Main menu" id="user-util-collapse">
                   <hr class="d-lg-none vw-100 my-0">
                   <ul class="navbar-nav justify-content-lg-end w-100 fw-semibold">


### PR DESCRIPTION
I think `navbars` was a typo; bootstrap uses the `navbar` class to opt-out of the default popper behavior (related to #825)