### PR TITLE
Remove extra vertical padding from the non-menu links in the mobile view

### DIFF
--- a/app/assets/stylesheets/modules/masthead.css
+++ b/app/assets/stylesheets/modules/masthead.css
@@ -118,6 +118,11 @@ header {
 
       vertical-align: middle;
     }
+
+    .top-nav-links a.nav-link {
+      --bs-nav-link-padding-y: 0.5rem;
+    }
+
     a:has(+ button) {
       padding-inline-end: 0.3125rem;
     }
@@ -169,6 +174,10 @@ header {
 
     .dropdown-toggle {
       width: 60px;
+    }
+
+    .top-nav-links {
+      margin-top: 0.5rem;
     }
   }
 }

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -41,7 +41,7 @@
         <div class="masthead lg-shadow">
           <div class="container-fluid">
             <div class="d-flex flex-wrap align-items-end justify-content-between gap-3">
-              <div class="navbar w-100 ms-lg-auto border-light">
+              <div class="navbar w-100 ms-lg-auto pt-0 border-light">
                 <nav class="collapse navbar-collapse align-items-start justify-content-lg-end navbar-expand-lg d-lg-flex flex-column flex-lg-row" aria-label="Main menu" id="user-util-collapse">
                   <ul class="navbar-nav justify-content-lg-end w-100 fw-semibold">
                     <li class="nav-item">
@@ -138,7 +138,7 @@
                       </ul>
                     </li>
                   </ul>
-                  <ul class="navbar-nav d-lg-none gap-0 w-100">
+                  <ul class="navbar-nav d-lg-none gap-0 w-100 top-nav-links">
                     <li class="nav-item border-0">
                       <a class="nav-link fs-5 su-underline" href="https://searchworks.stanford.edu">SearchWorks Catalog</a>
                       <a class="nav-link fs-5 su-underline py-0 ps-2 ms-2" href="https://searchworks.stanford.edu/articles">Articles+</a>


### PR DESCRIPTION
After:
<img width="892" alt="Screenshot 2025-06-16 at 15 58 43" src="https://github.com/user-attachments/assets/9bc6eab1-ba29-41c9-a41c-40e4137c722f" />

Before:
<img width="868" alt="Screenshot 2025-06-16 at 15 59 19" src="https://github.com/user-attachments/assets/7036a431-8f39-4291-afc5-e7ef365e71f1" />

Part of #825 