### PR TITLE
Prevent flappy feature spec

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,11 +33,12 @@ Rails.application.routes.draw do
 
   constraints(lambda { |request| request.params[:q].blank? || request.params[:q].scrub.blank? }) do
     get '/' => 'pages#home'
-    get '/all' => 'pages#home'
+    get '/all' => 'pages#home', as: 'homepage'
   end
-
+  constraints(lambda { |request| request.params[:q]&.scrub&.present? }) do
+    get '/all' => 'search#index', as: 'search'
+  end
   root to: 'search#index'
-  get '/all' => 'search#index', as: 'search'
   get '/all/opensearch' => 'opensearch#opensearch', as: 'opensearch', :defaults => { :format => 'xml' }
   get '/all/:endpoint' => 'search#show'
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.feature 'Homepage', :js do
   before do
-    visit root_path
+    visit homepage_path
   end
 
   scenario 'has text for top level headings and sections for search tools and other sources' do


### PR DESCRIPTION
Sometimes the homepage_feature_spec was getting routed to the show route.  This conditional makes the routing more deterministic.