### PR TITLE
add link underlining for focused menu arrows

### DIFF
--- a/app/assets/stylesheets/modules/masthead.css
+++ b/app/assets/stylesheets/modules/masthead.css
@@ -43,7 +43,7 @@
     transition: transform 0.5s;
     width: 40px;
 
-    &:hover {
+    &:hover, &:focus {
       --dropdown-hover-border-color: rgb(93 75 60);
     }
 


### PR DESCRIPTION

<img width="659" alt="Screenshot 2025-06-17 at 10 51 42 AM" src="https://github.com/user-attachments/assets/ec88d70b-3e7e-4437-83f7-266d3521188a" />
