### PR TITLE
Don't use blue as the active cover on dropdown items

### DIFF
--- a/app/assets/stylesheets/component-library-overrides.css
+++ b/app/assets/stylesheets/component-library-overrides.css
@@ -39,10 +39,12 @@ header {
   --bs-dropdown-padding-y: 0;
   --bs-dropdown-item-padding-y: 1.25rem;
   --bs-dropdown-item-padding-x: 1.25rem;
+  --bs-dropdown-link-hover-bg: var(--stanford-10-black);
   --bs-dropdown-link-hover-color: var(--stanford-archway);
+  --bs-dropdown-link-active-bg: var(--stanford-10-black);
+  --bs-dropdown-link-active-color: var(--stanford-archway);
   --bs-dropdown-border-width: 0;
   --bs-dropdown-border-radius: 0;
-  --bs-dropdown-link-hover-bg: var(--stanford-10-black);
   .dropdown-item {
     font-weight: 600;
   }


### PR DESCRIPTION
Fixes #848
<img width="335" alt="Screenshot 2025-06-17 at 10 47 49 AM" src="https://github.com/user-attachments/assets/e0653433-965c-4246-acb9-ba9fa3738d75" />
