### PR TITLE
Use the grid system to create space between the main search tools and the aside

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -12,7 +12,7 @@
 
 <div class="container-fluid py-5" style="max-width: 1242px">
   <div class="row">
-    <div class="col-xxl-7 col-md-8 pe-xxl-5 me-xxl-5">
+    <div class="col-xl-7 col-md-8">
       <header class="h3 fw-semibold">Stanford University Libraries' search tools</header>
       <div class="mb-3">
         <div class="mb-1 fw-medium"> SearchWorks <span class="fw-bold">Catalog</span> </div>
@@ -31,7 +31,7 @@
         </div>
       <% end %>
     </div>
-    <div class="col-xxl-4 col-md-4 ps-xxl-5 ms-xxl-5">
+    <div class="col-xl-4 offset-xl-1 col-md-4 ps-xxl-5">
       <aside class="p-3 bg-secondary">
         <header class="h3 fw-semibold mb-3">Other sources searched</header>
         <% %w[library_website_api_search lib_guides_search subject_specialist_search].each do |scope| %>


### PR DESCRIPTION
This helps avoids an awkward re-flow when switching from xl to xxl breakpoints:

current xl:
<img width="454" alt="Screenshot 2025-06-17 at 08 54 55" src="https://github.com/user-attachments/assets/ce0b3247-f79f-41db-89e5-a7b2fb2e81ab" />

xxl:
<img width="530" alt="Screenshot 2025-06-17 at 08 55 06" src="https://github.com/user-attachments/assets/412a7901-dd95-486c-a726-e0ac816228d0" />

After, this change isn't as dramatic (and xxl looks substantially the same):
<img width="1048" alt="Screenshot 2025-06-17 at 08 53 55" src="https://github.com/user-attachments/assets/e51df111-3dd1-440f-8852-e2522168bccd" />
