### PR TITLE
Tweak the user-util-collapse margins to better approximate the library website.

### DIFF
--- a/app/assets/stylesheets/modules/masthead.css
+++ b/app/assets/stylesheets/modules/masthead.css
@@ -111,7 +111,9 @@ header {
   }
 
   #user-util-collapse {
-    margin-top: 0.75rem;
+    margin-bottom: 0.25rem;
+    margin-top: 0.8rem;
+
     a.nav-link {
       --bs-nav-link-padding-y: 1rem;
       --bs-navbar-nav-link-padding-x: 1.25rem;


### PR DESCRIPTION
Before, our menu bar didn't quite line up with upstream.

After:
<img width="731" alt="Screenshot 2025-06-17 at 09 06 29" src="https://github.com/user-attachments/assets/6023b513-05ea-4c02-b9ea-bcdf8ebf4c20" />
