### PR TITLE
Update result formats to match design

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,26 @@ module ApplicationHelper
     content_for :title, page_title.compact.join
   end
 
+  def format_year(date_string)
+    return nil if date_string.blank?
+
+    date = Date.parse(date_string)
+    year = date.strftime('%Y')
+    "(#{year})"
+  rescue Date::Error
+    nil
+  end
+
+  def journal_details(composed_title)
+    return '' if composed_title.blank?
+
+    search_link_match = composed_title.match(%r{</searchlink>(.*)}i)
+    return search_link_match[1] if search_link_match
+
+    italic_match = composed_title.match(%r{\u003C/i\u003E(.*)}i)
+    italic_match ? italic_match[1] : ''
+  end
+
   def visually_hidden_service(service_name)
     tag.span service_name.humanize(capitalize: false), class: 'visually-hidden'
   end

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -3,5 +3,6 @@
 class SearchResult
   include ActiveModel::API
   attr_accessor :title, :format, :icon, :physical, :author, :journal, :imprint, :description,
-                :online_badge, :link, :thumbnail, :fulltext_link_html
+                :online_badge, :link, :thumbnail, :fulltext_link_html, :pub_date, :pub_year,
+                :composed_title
 end

--- a/app/services/article_search_service.rb
+++ b/app/services/article_search_service.rb
@@ -15,6 +15,7 @@ class ArticleSearchService < AbstractSearchService
       json['response']['pages']['total_count'].to_i
     end
 
+    # rubocop:disable Metrics/MethodLength
     def results
       solr_docs = json['response']['docs']
       solr_docs.collect do |doc|
@@ -24,7 +25,9 @@ class ArticleSearchService < AbstractSearchService
           format: doc['eds_publication_type'],
           journal: doc['eds_source_title'],
           icon: 'notebook.svg',
-          description: doc['eds_abstract']
+          description: doc['eds_abstract'],
+          pub_date: doc['eds_publication_date'],
+          composed_title: doc['eds_composed_title']
         )
 
         # Break up the HTML string into the pieces we use
@@ -42,6 +45,7 @@ class ArticleSearchService < AbstractSearchService
         result
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/app/services/catalog_search_service.rb
+++ b/app/services/catalog_search_service.rb
@@ -23,7 +23,8 @@ class CatalogSearchService < AbstractSearchService
           author: doc['author_person_display']&.first,
           format: doc['format_main_ssim']&.first,
           icon: 'notebook.svg',
-          description: doc['summary_display'].try(:join)
+          description: doc['summary_display'].try(:join),
+          pub_year: doc['pub_year_ss']
         )
 
         # Break up the HTML string into the pieces we use

--- a/app/views/search/_result_details.html.erb
+++ b/app/views/search/_result_details.html.erb
@@ -7,9 +7,22 @@
   <div class="pb-1 ">
     <%= image_tag result.icon, aria: { hidden: true }, class: 'icon mx-1' %>
     <span class="fw-semibold"><%= result.format %></span>
-    <% if result.physical %>
-      <% if result.format %>&mdash; <% end %>
-      <%= result.physical %>
+    <% case result.format %>
+    <% when 'Book' %>
+      <% if result.pub_year %>
+        (<%= result.pub_year %>)
+      <% else %>
+        <%= format_year(result.pub_date) %>
+      <% end %>
+    <% when 'eBook' %>
+      <%= format_year(result.pub_date) %>
+    <% else %>
+      <% if result.journal.present? %>
+        &mdash; <span class="fst-italic"><%= result.journal %></span><%= journal_details(result.composed_title) %>
+      <% elsif result.physical %>
+        <% if result.format %>&mdash; <% end %>
+        physical <%= result.physical %>
+      <% end %>
     <% end %>
   </div>
 <% end %>
@@ -18,9 +31,6 @@
 <% end %>
 <% if result.imprint.present? %>
   <div class="pb-1"><%= result.imprint %></div>
-<% end %>
-<% if result.journal.present? %>
-  <div class="pb-1"><%= result.journal %></div>
 <% end %>
 
 <% if result.description.present? %>

--- a/spec/views/search/_result_details.html.erb_spec.rb
+++ b/spec/views/search/_result_details.html.erb_spec.rb
@@ -46,4 +46,90 @@ RSpec.describe 'search/_result_details' do
       expect(rendered).to have_link('Link', href: '#')
     end
   end
+
+  context 'with a Book' do
+    let(:result) do
+      SearchResult.new(
+        format: 'Book',
+        title: 'Title',
+        icon: 'notebook.svg',
+        link: 'http://example.com',
+        author: 'The Author',
+        pub_year: '2022',
+        fulltext_link_html: '<a href="#">Link</a>'
+      )
+    end
+
+    it 'displays the Book format' do
+      expect(rendered).to have_content('Book')
+    end
+
+    it 'displays the formatted publication year' do
+      expect(rendered).to have_content('(2022)')
+    end
+  end
+
+  context 'with an eBook' do
+    let(:result) do
+      SearchResult.new(
+        format: 'eBook',
+        title: 'Title',
+        icon: 'notebook.svg',
+        link: 'http://example.com',
+        author: 'The Author',
+        pub_date: '2022-06-15',
+        fulltext_link_html: '<a href="#">Link</a>'
+      )
+    end
+
+    it 'displays the eBook format' do
+      expect(rendered).to have_content('eBook')
+    end
+
+    it 'displays the formatted publication year' do
+      expect(rendered).to have_content('(2022)')
+    end
+  end
+
+  context 'when journal information is present' do
+    context 'with a composed title with encoded italics' do
+      let(:result) do
+        SearchResult.new(
+          format: 'Academic Journal',
+          title: 'Title',
+          icon: 'notebook.svg',
+          link: 'http://example.com',
+          author: 'The Author',
+          pub_date: '2022-06-15',
+          fulltext_link_html: '<a href="#">Link</a>',
+          journal: 'Journal Title',
+          composed_title: "\u003Ci\u003EJournal Title\u003C/i\u003E pages 11-23"
+        )
+      end
+
+      it 'displays the formatted journal title and details' do
+        expect(rendered).to have_content('Journal Title pages 11-23')
+      end
+    end
+
+    context 'with a composed title with a searchLink' do
+      let(:result) do
+        SearchResult.new(
+          format: 'Academic Journal',
+          title: 'Title',
+          icon: 'notebook.svg',
+          link: 'http://example.com',
+          author: 'The Author',
+          pub_date: '2022-06-15',
+          fulltext_link_html: '<a href="#">Link</a>',
+          journal: 'Journal Title',
+          composed_title: "\u003CsearchLink fieldcode=\"JN\" term=\"%22EAST+BAY+TIMES%22\"\u003EEAST BAY TIMES\u003C/searchLink\u003E pages 11-23"
+        )
+      end
+
+      it 'displays the formatted journal title and details' do
+        expect(rendered).to have_content('Journal Title pages 11-23')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #832

Some of these details were discussed with @dbranchini outside of the issue.

<img width="614" alt="Screenshot 2025-06-17 at 3 41 30 PM" src="https://github.com/user-attachments/assets/1543295d-27c0-4243-a93a-b57cb1d94062" />

<img width="122" alt="Screenshot 2025-06-17 at 3 37 34 PM" src="https://github.com/user-attachments/assets/1d7d3fcb-c870-4920-b285-ece42f6cca9b" />

<img width="367" alt="Screenshot 2025-06-17 at 3 37 28 PM" src="https://github.com/user-attachments/assets/5b123069-e3aa-4083-8422-689c03b0555f" />

<img width="130" alt="Screenshot 2025-06-17 at 3 54 45 PM" src="https://github.com/user-attachments/assets/9fa67c56-733a-45e5-b1ab-ee2679521815" />

