### PR TITLE
Set container-fluid-padding to 50px for xs + sm screens

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,8 +23,14 @@ body {
 }
 
 .container-fluid {
-  --container-fluid-padding: 100px;
+  --container-fluid-padding: 50px;
   width: calc(100% - var(--container-fluid-padding) + var(--bs-gutter-x));
+}
+
+@media (min-width: 7682px) {
+  .container-fluid {
+    --container-fluid-padding: 100px;
+  }
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
Fixes #861

445px:
<img width="463" alt="Screenshot 2025-06-17 at 17 03 05" src="https://github.com/user-attachments/assets/d5c79343-fc01-443c-a4ee-3bc093ad3218" />
