### PR TITLE
Remove unwanted text in results details

### DIFF
--- a/app/views/search/_result_details.html.erb
+++ b/app/views/search/_result_details.html.erb
@@ -21,7 +21,7 @@
         &mdash; <span class="fst-italic"><%= result.journal %></span><%= journal_details(result.composed_title) %>
       <% elsif result.physical %>
         <% if result.format %>&mdash; <% end %>
-        physical <%= result.physical %>
+        <%= result.physical %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
I missed removing this static text that I had inserted for testing. We don't want it! Thanks @dnoneill for the spot.