### PR TITLE
small accessibility fixes

### DIFF
--- a/app/views/search/_result_details.html.erb
+++ b/app/views/search/_result_details.html.erb
@@ -5,7 +5,7 @@
 
 <% if result.icon.present? || result.physical %>
   <div class="pb-1">
-    <%= image_tag result.icon, aria: { hidden: true }, class: 'icon mx-1' %>
+    <%= image_tag result.icon, aria: { hidden: true }, alt: '', class: 'icon mx-1' %>
     <span class="fw-semibold"><%= result.format %></span>
     <% case result.format %>
     <% when 'Book' %>

--- a/app/views/search/_result_with_thumbnail.html.erb
+++ b/app/views/search/_result_with_thumbnail.html.erb
@@ -1,6 +1,6 @@
 <div class="row mb-3">
   <div class="col-sm-3">
-      <%= link_to result.link, aria: { hidden: true } do %>
+      <%= link_to result.link, aria: { hidden: true }, tabindex: '-1' do %>
           <%= image_tag result.thumbnail, class: 'thumbnail img-fluid', alt: '' %>
       <% end %>
   </div>


### PR DESCRIPTION
closes #772 
Before:
![Screenshot 2025-06-18 at 12 12 48 PM](https://github.com/user-attachments/assets/12088d63-941d-493b-be83-6a31ac545e61)

![Screenshot 2025-06-18 at 12 12 56 PM](https://github.com/user-attachments/assets/2fc8ea94-1bb4-48ec-ae49-0ae7d198db82)

![Screenshot 2025-06-18 at 12 27 08 PM](https://github.com/user-attachments/assets/48159907-5979-4208-87d9-ce18269129ac)

After:
![Screenshot 2025-06-18 at 12 32 33 PM](https://github.com/user-attachments/assets/77fd848e-52e4-44d2-8a91-047c04043edd)
![Screenshot 2025-06-18 at 12 31 51 PM](https://github.com/user-attachments/assets/27dc3b88-cebe-49b2-aa3a-5e2923d65be0)

The AA contrast issue is that same issue we have been running into on the footer.
