### PR TITLE
Extract SearchPresenter#formatted_total to handle libguides weirdness.

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -13,14 +13,6 @@ class SearchController < ApplicationController
     @presenter = SearchPresenter.new(service, result, params_q_scrubbed)
   end
 
-  # JSON API for Searchworks' mini-bento
-  def lib_guides
-    service = Service.new('lib_guides')
-
-    result = service.query(params_q_scrubbed)
-    @presenter = SearchPresenter.new(service, result, params_q_scrubbed)
-  end
-
   private
 
   def handle_outdated_browser

--- a/app/models/search_presenter.rb
+++ b/app/models/search_presenter.rb
@@ -14,6 +14,12 @@ class SearchPresenter
     @service.name
   end
 
+  def formatted_total
+    return '100+' if service_name == 'lib_guides' && total == 100
+
+    ActiveSupport::NumberHelper.number_to_delimited(total)
+  end
+
   def no_results?
     total.zero?
   end

--- a/app/views/search/_see_all.html.erb
+++ b/app/views/search/_see_all.html.erb
@@ -1,14 +1,10 @@
 <%= link_to presenter.see_all_link, class: "btn btn-outline-secondary text-nowrap" do %>
-  <% if presenter.service_name == 'lib_guides' && presenter.total == 100 %>
-    See 100+ <%= visually_hidden_service(presenter.service_name) %> results
+  <% case presenter.total -%>
+  <% when 1 %>
+    See <%= presenter.formatted_total %> <%= visually_hidden_service(presenter.service_name) %> result
+  <% when 2, 3 %>
+    See <%= presenter.formatted_total %> <%= visually_hidden_service(presenter.service_name) %> results
   <% else %>
-   	<% case presenter.total -%>
-  	<% when 1 %>
-      See <%= number_with_delimiter(presenter.total) %> <%= visually_hidden_service(presenter.service_name) %> result
-  	<% when 2, 3 %>
-  	  See <%= number_with_delimiter(presenter.total) %> <%= visually_hidden_service(presenter.service_name) %> results
-    <% else %>
-      See all <%= number_with_delimiter(presenter.total) %> <%= visually_hidden_service(presenter.service_name) %> results
-    <% end %>
+    See all <%= presenter.formatted_total %> <%= visually_hidden_service(presenter.service_name) %> results
   <% end %>
 <% end %>

--- a/app/views/search/show.json.jbuilder
+++ b/app/views/search/show.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.total @presenter.total == 100 ? '100+' : @presenter.total
+json.total @presenter.formatted_total
 json.app_link @presenter.see_all_link

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,6 @@ Rails.application.routes.draw do
   end
   root to: 'search#index'
   get '/all/opensearch' => 'opensearch#opensearch', as: 'opensearch', :defaults => { :format => 'xml' }
-  get '/all/xhr_search/lib_guides' => 'search#lib_guides',  defaults: { format: 'json' }
+  get '/all/xhr_search/:endpoint' => 'search#show',  defaults: { format: 'json' }
   get '/all/:endpoint' => 'search#show'
 end

--- a/spec/views/search/_module_heading.html.erb_spec.rb
+++ b/spec/views/search/_module_heading.html.erb_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'search/_module_heading' do
     it 'renders' do
       expect(rendered).to have_css('.result-set-heading', text: 'Guides')
       expect(rendered).to have_css('.result-set-subheading', text: /Course and topic guides/)
-      expect(rendered).to have_link 'See 100+ lib guides results'
+      expect(rendered).to have_link 'See all 100+ lib guides results'
     end
   end
 end


### PR DESCRIPTION
See #750 and #822 for the whole saga. This changes the bento label back to "See all 100+ lib guides results", which we seem to have lost in #822 ?
