### PR TITLE
Fix aside padding after guides

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -52,7 +52,7 @@
     <aside class="d-none d-xl-block col-xl-3">
       <div class="bg-secondary py-3 px-4">
         <div id="webside-aside" class="pb-5"></div>
-        <div id="guides-aside"></div>
+        <div id="guides-aside" class="pb-5"></div>
         <div id="specialist-aside"></div>
       </div>
     </aside>


### PR DESCRIPTION
After:
<img width="412" alt="Screenshot 2025-06-18 at 10 19 13" src="https://github.com/user-attachments/assets/b0b4866a-2575-4577-b8df-e516bc8d72fd" />
