### PR TITLE
Move default icon behavior to the helper

### DIFF
--- a/app/services/article_search_service.rb
+++ b/app/services/article_search_service.rb
@@ -27,7 +27,7 @@ class ArticleSearchService < AbstractSearchService
           title: doc['eds_title'],
           format:,
           journal: doc['eds_source_title'],
-          icon: IconMappingHelper::HASH[format] || 'notebook.svg',
+          icon: icon_for(format),
           description: doc['eds_abstract'],
           pub_date: doc['eds_publication_date'],
           composed_title: doc['eds_composed_title']

--- a/app/services/catalog_search_service.rb
+++ b/app/services/catalog_search_service.rb
@@ -25,7 +25,7 @@ class CatalogSearchService < AbstractSearchService
           physical: doc['physical']&.first,
           author: doc['author_person_display']&.first,
           format: doc['format_main_ssim']&.first,
-          icon: IconMappingHelper::HASH[format] || 'notebook.svg',
+          icon: icon_for(format),
           description: doc['summary_display'].try(:join),
           pub_year: doc['pub_year_ss']
         )

--- a/app/services/icon_mapping_helper.rb
+++ b/app/services/icon_mapping_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module IconMappingHelper
+  DEFAULT_ICON = 'notebook.svg'
   HASH = {
     'Loose-leaf' => 'notepad-1.svg',
     'Report' => 'notepad-1.svg',
@@ -28,4 +29,8 @@ module IconMappingHelper
     'Video' => 'camera-film-1.svg',
     'Videos' => 'camera-film-1.svg'
   }.freeze
+
+  def icon_for(format, default_format = 'Book')
+    HASH[format] || HASH[default_format] || DEFAULT_ICON
+  end
 end


### PR DESCRIPTION
I feel if we have this helper that maps formats to filenames we should provide a way to speak in default formats.