### PR TITLE
Add padding to the end of the search input

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -3,7 +3,7 @@
   <div class="container-fluid" style="max-width: 600px">
     <form class="search-query-form d-flex" action="/all" accept-charset="UTF-8" method="get">
       <label class="visually-hidden" for="q">search for</label>
-      <%= text_field_tag 'q', params[:q], class: "search-q q form-control rounded-left rounded-start", type: 'search', autocomplete: 'off', spellcheck: false, required: true %>
+      <%= text_field_tag 'q', params[:q], class: "search-q q form-control rounded-left rounded-start pe-2", type: 'search', autocomplete: 'off', spellcheck: false, required: true %>
       <button class="btn btn-secondary search-btn d-flex align-items-center justify-content-center" type="submit" id="search"><span class="submit-search-text">Search</span></button>
     </form>
   </div>


### PR DESCRIPTION
Maybe a solution to the spacing aspect of https://github.com/sul-dlss/sul-bento-app/issues/903?

Before
<img width="171" alt="Screenshot 2025-06-18 at 11 43 52 AM" src="https://github.com/user-attachments/assets/f0563a76-bffe-481a-9ae0-75b0ab4679fb" />

After
<img width="189" alt="Screenshot 2025-06-18 at 11 43 38 AM" src="https://github.com/user-attachments/assets/d6e605e9-7404-4d24-b867-4becbb0e3989" />