### PR TITLE
Some archives results have mixed-case types.

### DIFF
--- a/app/models/archives_result.rb
+++ b/app/models/archives_result.rb
@@ -5,12 +5,12 @@ class ArchivesResult
   attr_accessor :title, :type, :physical, :description, :link
 
   def icon
-    case type
+    case type.downcase
     when 'collection'
       'archive.svg'
-    when 'Series'
+    when 'series'
       'folder.svg'
-    when 'File', 'Item'
+    when 'file', 'item'
       'file.svg'
     end
   end

--- a/spec/models/archives_result_spec.rb
+++ b/spec/models/archives_result_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ArchivesResult do
+  describe '#icon' do
+    it 'ignores the format case' do
+      expect(described_class.new(type: 'Collection').icon).to eq('archive.svg')
+    end
+  end
+end


### PR DESCRIPTION
See https://archives.stanford.edu/catalog/m1047_aspace_ref52_7yo, and presumably others.