### PR TITLE
Provide the header + count value even in an error state.

### DIFF
--- a/app/models/search_presenter.rb
+++ b/app/models/search_presenter.rb
@@ -2,7 +2,7 @@
 
 class SearchPresenter
   delegate :i18n_key, :see_all_url_template, to: :@service
-  delegate :total, :results, to: :@result
+  delegate :total, :results, to: :@result, allow_nil: true
 
   def initialize(service, result, query_text)
     @service = service
@@ -21,7 +21,7 @@ class SearchPresenter
   end
 
   def no_results?
-    total.zero?
+    total.nil? || total.zero?
   end
 
   def no_answer?

--- a/app/views/search/_module.html.erb
+++ b/app/views/search/_module.html.erb
@@ -1,6 +1,10 @@
-<div id="<%= presenter.service_name %>" class="module-contents mb-3" data-controller="module" data-module-count-id-value="<%= presenter.service_name %>_count" data-module-total-value="<%= number_with_delimiter(presenter.total) %>">
+<div id="<%= presenter.service_name %>" class="module-contents mb-3" data-controller="module" data-module-count-id-value="<%= presenter.service_name %>_count" data-module-total-value="<%= number_with_delimiter(presenter.total.to_i) %>">
     <%= render 'module_heading', presenter: %>
-    <% if presenter.no_results? %>
+    <% if presenter.no_answer? %>
+      <div class="alert alert-danger">
+        There was an error retrieving your <%= t("#{presenter.service_name}_search.micro_display_name") %> results.
+      </div>
+    <% elsif presenter.no_results? %>
         <%= render 'no_results', presenter: %>
     <% else %>
         <ol class="list-unstyled">

--- a/app/views/search/show.html.erb
+++ b/app/views/search/show.html.erb
@@ -1,9 +1,3 @@
 <%= turbo_frame_tag "#{@presenter.service_name}_module" do %>
-  <% if @presenter.no_answer? %>
-    <div class="alert alert-danger">
-      There was an error retrieving your <%= t("#{params[:endpoint]}_search.micro_display_name") %> results.
-    </div>
-  <% else %>
-    <%= render 'module', presenter: @presenter %>
-  <% end %>
+  <%= render 'module', presenter: @presenter %>
 <% end %>


### PR DESCRIPTION
... this way, we're not leaving errors without context (or blank values in result types list)