### PR TITLE
Handle the 'aside' modules without duplicating content.

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,29 +2,44 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 
-// Copy library and guides to the sidebar that appears for XL
-document.addEventListener('turbo:frame-render', (event) => {
-  if (event.target.id === 'library_website_api_module') {
-    document.getElementById('webside-aside').innerHTML = event.target.innerHTML
-    event.target.classList.add('d-xl-none')
+window.addEventListener('resize', handleResponsiveAside);
+document.addEventListener('turbo:load', resetAndHandleResponsiveAside);
+document.addEventListener('DOMContentLoaded', resetAndHandleResponsiveAside);
+
+
+let lastAsideVisibility = false;
+
+function resetAndHandleResponsiveAside() {
+  lastAsideVisibility = false;
+  handleResponsiveAside();
+}
+
+function handleResponsiveAside() {
+  const aside = document.getElementById('modules-aside');
+
+  if (aside === undefined || aside.checkVisibility === undefined) return;
+
+  const newVisibility = aside.checkVisibility();
+
+  if (newVisibility !== lastAsideVisibility) {
+    lastAsideVisibility = newVisibility;
+
+    if (newVisibility) {
+      reparentAsideModules('modules-aside');
+    } else {
+      reparentAsideModules('modules');
+    }
   }
-  if (event.target.id === 'lib_guides_module') {
-    document.getElementById('guides-aside').innerHTML = event.target.innerHTML
-    event.target.classList.add('d-xl-none')
-  }
-})
+};
 
-document.addEventListener('DOMContentLoaded', (event) => {
-  const specialist = document.getElementById('specialist-main')
-  document.getElementById('specialist-aside').innerHTML = specialist.innerHTML
-  specialist.classList.add('d-xl-none')
-})
+function reparentAsideModules(parentId) {
+  const els = [
+    document.getElementById('library_website_api_module'),
+    document.getElementById('lib_guides_module'),
+    document.getElementById('specialist-main')
+  ];
 
-document.addEventListener('turbo:load', (event) => {
-  const specialist = document.getElementById('specialist-main')
-
-  if (specialist.classList.contains('d-xl-none')) return;
-
-  document.getElementById('specialist-aside').innerHTML = specialist.innerHTML
-  specialist.classList.add('d-xl-none')
-})
+  els.forEach((el) => {
+    document.getElementById(parentId).appendChild(el);
+  })
+}

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -50,10 +50,7 @@
     </div>
 
     <aside class="d-none d-xl-block col-xl-3">
-      <div class="bg-secondary py-3 px-4">
-        <div id="webside-aside" class="pb-5"></div>
-        <div id="guides-aside" class="pb-5"></div>
-        <div id="specialist-aside"></div>
+      <div id="modules-aside" class="bg-secondary py-3 px-4 gap-5 d-flex flex-column">
       </div>
     </aside>
   </div>


### PR DESCRIPTION
The current implementation breaks the top links for website + guides (because the DOM ids are duplicated in the `#modules` and the `aside`). This PR just re-parents the modules if it needs to 🤷‍♂️ 