### PR TITLE
Prevent thubmnails from using the full width at small viewports

### DIFF
--- a/app/views/exhibits_results/_exhibits_result.html.erb
+++ b/app/views/exhibits_results/_exhibits_result.html.erb
@@ -1,10 +1,10 @@
 <div class="row mb-3">
-  <div class="col-sm-3">
+  <div class="col-3">
       <%= link_to exhibits_result.link, aria: { hidden: true }, tabindex: '-1' do %>
           <%= image_tag exhibits_result.thumbnail, class: 'thumbnail img-fluid', alt: '' %>
       <% end %>
   </div>
-  <div class="col-sm-9">
+  <div class="col-9">
       <div class="result-title fs-1125 fw-medium pt-2 pb-1">
         <%= link_to exhibits_result.title.html_safe, exhibits_result.link %>
       </div>


### PR DESCRIPTION
Fixes #917
<img width="476" alt="Screenshot 2025-06-19 at 6 46 58 AM" src="https://github.com/user-attachments/assets/3e3b1041-cb5b-4899-8a68-ddd67143d08b" />
