### PR TITLE
Remove top padding for exhibits

### DIFF
--- a/app/views/exhibits_results/_exhibits_result.html.erb
+++ b/app/views/exhibits_results/_exhibits_result.html.erb
@@ -5,7 +5,7 @@
       <% end %>
   </div>
   <div class="col-9">
-      <div class="result-title fs-1125 fw-medium pt-2 pb-1">
+      <div class="result-title fs-1125 fw-medium pb-1">
         <%= link_to exhibits_result.title.html_safe, exhibits_result.link %>
       </div>
 


### PR DESCRIPTION
Align the title with the top of the thumbnail.

<img width="525" alt="Screenshot 2025-06-19 at 6 50 08 AM" src="https://github.com/user-attachments/assets/43b6ce26-0fc4-4a4f-81a0-03630dcebab5" />

