### PR TITLE
Get the SUL footer + body content to all line up at xs breakpoints

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <% title %>
 <section class="bg-secondary py-5">
-  <div class="container-fluid" style="max-width: 1242px">
+  <div class="container-fluid container-xl">
     <h1 class="h2 fw-semibold">Search for books, articles, and more</h1>
     <form class="search-query-form d-flex" style="max-width: 729px; width: 75vw" action="/all" accept-charset="UTF-8" method="get">
       <label class="visually-hidden" for="q">search for</label>
@@ -10,7 +10,7 @@
   </div>
 </section>
 
-<div class="container-fluid py-5" style="max-width: 1242px">
+<div class="container-fluid container-xl py-5">
   <div class="row">
     <div class="col-xl-7 col-md-8">
       <header class="h3 fw-semibold mb-3">Stanford University Libraries' search tools</header>

--- a/app/views/shared/_sul_footer.html.erb
+++ b/app/views/shared/_sul_footer.html.erb
@@ -1,6 +1,6 @@
 <footer>
   <section id="pre-footer" class="py-4" aria-label="Library footer">
-    <div class="container">
+    <div class="container-fluid container-xl">
       <div class="row row-gap-3">
         <div
           id="sul-footer-img"


### PR DESCRIPTION
I don't know if this belongs in the component library, or is a consequence of how we're doing bento, but this PR gets the SUL footer to line up better in smaller breakpoints:


Before:
<img width="345" alt="Screenshot 2025-06-25 at 09 30 12" src="https://github.com/user-attachments/assets/64bc27bf-781f-47de-9cf9-c5b0af3b78ef" />

After:
<img width="522" alt="Screenshot 2025-06-25 at 09 28 39" src="https://github.com/user-attachments/assets/d436c020-50ff-41c7-81fa-72359f1d60f5" />
