### PR TITLE
Remove obsolete platforms from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   gem "axe-core-rspec"
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem 'debug', platforms: %i[ mri mingw x64_mingw ]
+  gem 'debug'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara'
   gem 'rspec'


### PR DESCRIPTION
Resolves these warnings:
[DEPRECATED] Platform :mingw, :x64_mingw is deprecated. Please use platform :windows instead. [DEPRECATED] Platform :mingw, :mswin, :x64_mingw is deprecated. Please use platform :windows instead.