### PR TITLE
fix search anchors so they don't reload the page

### DIFF
--- a/app/views/search/_found_types.html.erb
+++ b/app/views/search/_found_types.html.erb
@@ -3,7 +3,7 @@
   <ul class="d-flex flex-wrap align-self-center list-inline column-gap-4 row-gap-2 mb-0">
     <% enabled_searchers.each do |searcher| %>
       <li class="d-flex position-relative align-items-start">
-        <a href="#<%= searcher.name %>" class="stretched-link"><%= t("short_display_name", scope: searcher.i18n_key) %></a>
+        <a href="#<%= searcher.name %>" data-turbo="false" class="stretched-link"><%= t("short_display_name", scope: searcher.i18n_key) %></a>
         <span class="badge rounded-pill text-bg-secondary ms-1">
           <turbo-frame id="<%= searcher.name %>_count">&nbsp;</turbo-frame>
         </span>


### PR DESCRIPTION
Right now when a user clicks on an anchor link it will reload the page